### PR TITLE
docs: fix README content issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build](https://github.com/ballerina-platform/module-ballerinax-hubspot.marketing.subscriptions/actions/workflows/ci.yml/badge.svg)](https://github.com/ballerina-platform/module-ballerinax-hubspot.marketing.subscriptions/actions/workflows/ci.yml)
 [![GitHub Last Commit](https://img.shields.io/github/last-commit/ballerina-platform/module-ballerinax-hubspot.marketing.subscriptions.svg)](https://github.com/ballerina-platform/module-ballerinax-hubspot.marketing.subscriptions/commits/master)
-[![GitHub Issues](https://img.shields.io/github/issues/ballerina-platform/ballerina-library/module/hubspot.marketing.subscriptions.svg?label=Open%20Issues)](https://github.com/ballerina-platform/ballerina-library/labels/module%hubspot.marketing.subscriptions)
+[![GitHub Issues](https://img.shields.io/github/issues/ballerina-platform/ballerina-library/module/hubspot.marketing.subscriptions.svg?label=Open%20Issues)](https://github.com/ballerina-platform/ballerina-library/labels/module%2Fhubspot.marketing.subscriptions)
 
 ## Overview
 
@@ -30,21 +30,21 @@ Within app developer accounts, you can create a [Developer Test Account](https:/
 
 1. Navigate to "Test Account" section from the left sidebar.
 
-   ![Hubspot developer portal](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.marketing.subscriptions/main/docs/setup/resources/Test1.png)
+   ![HubSpot developer portal](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.marketing.subscriptions/main/docs/setup/resources/Test1.png)
 
 2. Click "Create developer test account".
 
-   ![Hubspot developer portal](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.marketing.subscriptions/main/docs/setup/resources/Test2.png)
+   ![HubSpot developer portal](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.marketing.subscriptions/main/docs/setup/resources/Test2.png)
 
 3. In the dialog box, provide a name to your test account and click "Create".
 
-   ![Hubspot developer portal](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.marketing.subscriptions/main/docs/setup/resources/Test3.png)
+   ![HubSpot developer portal](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.marketing.subscriptions/main/docs/setup/resources/Test3.png)
 
 ### Step 3: Create a HubSpot App under your account.
 
 1. In your developer account, navigate to the "Apps" section. Click "Create App".
 
-   ![Hubspot developer portal](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.marketing.subscriptions/main/docs/setup/resources/Test4.png)
+   ![HubSpot developer portal](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.marketing.subscriptions/main/docs/setup/resources/Test4.png)
 
 2. Provide the necessary details, including the app name and description.
 
@@ -52,7 +52,7 @@ Within app developer accounts, you can create a [Developer Test Account](https:/
 
 1. Move to the "Auth" Tab.
 
-   ![Hubspot developer portal](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.marketing.subscriptions/main/docs/setup/resources/Test5.png)
+   ![HubSpot developer portal](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.marketing.subscriptions/main/docs/setup/resources/Test5.png)
 
 2. In the Scopes section, add the following scopes for your app by using the "Add new scope" button.
 
@@ -60,17 +60,17 @@ Within app developer accounts, you can create a [Developer Test Account](https:/
    * `communication_preferences.statuses.batch.read`
    * `communication_preferences.statuses.batch.write`
 
-   ![Hubspot developer portal](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.marketing.subscriptions/main/docs/setup/resources/Test6.png)
+   ![HubSpot developer portal](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.marketing.subscriptions/main/docs/setup/resources/Test6.png)
 
 4. Add your Redirect URI in the appropriate section. You can also use _localhost_ addresses for local development purposes. Click "Create App".
 
-   ![Hubspot developer portal](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.marketing.subscriptions/main/docs/setup/resources/Test7.png)
+   ![HubSpot developer portal](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.marketing.subscriptions/main/docs/setup/resources/Test7.png)
 
 ### Step 5: Get your Client ID and Client Secret
 
 - Navigate to the "Auth" section of your app. Make sure to save the provided Client ID and Client Secret.
 
-   ![Hubspot developer portal](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.marketing.subscriptions/main/docs/setup/resources/Test8.png)
+   ![HubSpot developer portal](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.marketing.subscriptions/main/docs/setup/resources/Test8.png)
 
 ### Step 6: Setup Authentication Flow
 
@@ -88,7 +88,7 @@ Before proceeding with the Quickstart, make sure you have obtained the Access To
 
 2. Paste it in the browser and select your developer test account to authorize the app when prompted.
 
-   ![Hubspot developer portal](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.marketing.subscriptions/main/docs/setup/resources/Test9.png)
+   ![HubSpot developer portal](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.marketing.subscriptions/main/docs/setup/resources/Test9.png)
 
 3. An authorization code appears in the browser. Copy the code.
 

--- a/ballerina/README.md
+++ b/ballerina/README.md
@@ -29,21 +29,21 @@ Within app developer accounts, you can create a [Developer Test Account](https:/
 
 1. Navigate to "Test Account" section from the left sidebar.
 
-   ![Hubspot developer portal](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.marketing.subscriptions/main/docs/setup/resources/Test1.png)
+   ![HubSpot developer portal](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.marketing.subscriptions/main/docs/setup/resources/Test1.png)
 
 2. Click "Create developer test account".
 
-   ![Hubspot developer portal](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.marketing.subscriptions/main/docs/setup/resources/Test2.png)
+   ![HubSpot developer portal](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.marketing.subscriptions/main/docs/setup/resources/Test2.png)
 
 3. In the dialog box, provide a name to your test account and click "Create".
 
-   ![Hubspot developer portal](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.marketing.subscriptions/main/docs/setup/resources/Test3.png)
+   ![HubSpot developer portal](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.marketing.subscriptions/main/docs/setup/resources/Test3.png)
 
 ### Step 3: Create a HubSpot App under your account.
 
 1. In your developer account, navigate to the "Apps" section. Click "Create App".
 
-   ![Hubspot developer portal](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.marketing.subscriptions/main/docs/setup/resources/Test4.png)
+   ![HubSpot developer portal](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.marketing.subscriptions/main/docs/setup/resources/Test4.png)
 
 2. Provide the necessary details, including the app name and description.
 
@@ -51,7 +51,7 @@ Within app developer accounts, you can create a [Developer Test Account](https:/
 
 1. Move to the "Auth" Tab.
 
-   ![Hubspot developer portal](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.marketing.subscriptions/main/docs/setup/resources/Test5.png)
+   ![HubSpot developer portal](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.marketing.subscriptions/main/docs/setup/resources/Test5.png)
 
 2. In the Scopes section, add the following scopes for your app by using the "Add new scope" button.
 
@@ -59,17 +59,17 @@ Within app developer accounts, you can create a [Developer Test Account](https:/
    * `communication_preferences.statuses.batch.read`
    * `communication_preferences.statuses.batch.write`
 
-   ![Hubspot developer portal](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.marketing.subscriptions/main/docs/setup/resources/Test6.png)
+   ![HubSpot developer portal](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.marketing.subscriptions/main/docs/setup/resources/Test6.png)
 
 4. Add your Redirect URI in the appropriate section. You can also use _localhost_ addresses for local development purposes. Click "Create App".
 
-   ![Hubspot developer portal](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.marketing.subscriptions/main/docs/setup/resources/Test7.png)
+   ![HubSpot developer portal](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.marketing.subscriptions/main/docs/setup/resources/Test7.png)
 
 ### Step 5: Get your Client ID and Client Secret
 
 - Navigate to the "Auth" section of your app. Make sure to save the provided Client ID and Client Secret.
 
-   ![Hubspot developer portal](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.marketing.subscriptions/main/docs/setup/resources/Test8.png)
+   ![HubSpot developer portal](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.marketing.subscriptions/main/docs/setup/resources/Test8.png)
 
 ### Step 6: Setup Authentication Flow
 
@@ -87,7 +87,7 @@ Before proceeding with the Quickstart, make sure you have obtained the Access To
 
 2. Paste it in the browser and select your developer test account to authorize the app when prompted.
 
-   ![Hubspot developer portal](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.marketing.subscriptions/main/docs/setup/resources/Test9.png)
+   ![HubSpot developer portal](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.marketing.subscriptions/main/docs/setup/resources/Test9.png)
 
 3. An authorization code appears in the browser. Copy the code.
 


### PR DESCRIPTION
## Purpose

Fix README content issues identified in the HubSpot connector audit for the `ballerinax/hubspot.marketing.subscriptions` connector.

## Changes

- Replace 'Hubspot' with 'HubSpot' (brand-name occurrences only)
- Replace typo 'ave' with 'have'
- Fix encoding in the GitHub Issues badge URL (module%... -> module%2F...)

## Checklist
- [x] Linked to an issue (Refs `ballerina-platform/ballerina-library#8823`)
- [ ] Updated the changelog — N/A (docs-only)
- [ ] Added tests — N/A (docs-only)
- [ ] Updated the spec — N/A (docs-only)
- [x] Checked native-image compatibility — N/A (no code change)

Refs ballerina-platform/ballerina-library#8823