### PR TITLE
Improve operation summaries and add field descriptions

### DIFF
--- a/ballerina/client.bal
+++ b/ballerina/client.bal
@@ -23,7 +23,7 @@ import ballerina/http;
 public isolated client class Client {
     final http:Client clientEp;
     final readonly & ApiKeysConfig? apiKeyConfig;
-    # Gets invoked to initialize the `connector`.
+    # Gets invoked to initialize the `connector`
     #
     # + config - The configurations to be used when initializing the `connector` 
     # + serviceUrl - URL of the target service 
@@ -41,6 +41,7 @@ public isolated client class Client {
 
     # Batch update subscription status
     #
+    # + payload - A batch input public status request 
     # + headers - Headers to be sent with the request 
     # + return - successful operation 
     remote isolated function postCommunicationPreferencesV4StatusesBatchWrite(BatchInputPublicStatusRequest payload, map<string|string[]> headers = {}) returns BatchResponsePublicStatus|error {
@@ -56,7 +57,7 @@ public isolated client class Client {
         return self.clientEp->post(resourcePath, request, httpHeaders);
     }
 
-    # Retrieve a contact's unsubscribed status
+    # Get contact's unsubscribed status
     #
     # + subscriberIdString - The contact's email address
     # + headers - Headers to be sent with the request 
@@ -73,7 +74,7 @@ public isolated client class Client {
         return self.clientEp->get(resourcePath, httpHeaders);
     }
 
-    # Unsubscribe a contact from all subscriptions
+    # Unsubscribe contact from all
     #
     # + subscriberIdString - The contact's email address
     # + headers - Headers to be sent with the request 
@@ -93,6 +94,7 @@ public isolated client class Client {
 
     # Batch retrieve subscription statuses
     #
+    # + payload - A batch input string 
     # + headers - Headers to be sent with the request 
     # + queries - Queries to be sent with the request 
     # + return - successful operation 
@@ -110,8 +112,9 @@ public isolated client class Client {
         return self.clientEp->post(resourcePath, request, httpHeaders);
     }
 
-    # Batch unsubscribe contacts from all subscriptions
+    # Batch unsubscribe all contacts
     #
+    # + payload - A batch input string 
     # + headers - Headers to be sent with the request 
     # + queries - Queries to be sent with the request 
     # + return - successful operation 
@@ -129,7 +132,7 @@ public isolated client class Client {
         return self.clientEp->post(resourcePath, request, httpHeaders);
     }
 
-    # Retrieve all subscription status definitions
+    # Retrieve all subscription definitions
     #
     # + headers - Headers to be sent with the request 
     # + queries - Queries to be sent with the request 
@@ -145,8 +148,9 @@ public isolated client class Client {
         return self.clientEp->get(resourcePath, httpHeaders);
     }
 
-    # Batch retrieve contacts who have opted out of all communications
+    # Batch get opted-out contacts
     #
+    # + payload - A batch input string 
     # + headers - Headers to be sent with the request 
     # + queries - Queries to be sent with the request 
     # + return - successful operation 
@@ -164,7 +168,7 @@ public isolated client class Client {
         return self.clientEp->post(resourcePath, request, httpHeaders);
     }
 
-    # Get subscription preferences for a specific contact
+    # Get contact subscription prefs
     #
     # + subscriberIdString - The contact's email address
     # + headers - Headers to be sent with the request 
@@ -181,9 +185,10 @@ public isolated client class Client {
         return self.clientEp->get(resourcePath, httpHeaders);
     }
 
-    # Update a contact's subscription status
+    # Update contact subscription status
     #
     # + subscriberIdString - The contact's email address
+    # + payload - A partial public status request 
     # + headers - Headers to be sent with the request 
     # + return - successful operation 
     remote isolated function postCommunicationPreferencesV4StatusesSubscriberIdString(string subscriberIdString, PartialPublicStatusRequest payload, map<string|string[]> headers = {}) returns ActionResponseWithResultsPublicStatus|error {

--- a/ballerina/types.bal
+++ b/ballerina/types.bal
@@ -19,66 +19,115 @@
 
 import ballerina/http;
 
+# Response object containing async action results with wide-status entries and execution metadata
 public type ActionResponseWithResultsPublicWideStatus record {
+    # Timestamp when the action completed
     string completedAt;
+    # Total number of errors encountered during processing
     int:Signed32 numErrors?;
+    # Timestamp when the action was requested
     string requestedAt?;
+    # Timestamp when the action began processing
     string startedAt;
+    # Map of related resource links associated with the response
     record {|string...;|} links?;
+    # List of wide-status results returned by the action
     PublicWideStatus[] results;
+    # List of errors encountered during the action execution
     StandardError[] errors?;
+    # Current processing state of the action: PENDING, PROCESSING, CANCELED, or COMPLETE
     "PENDING"|"PROCESSING"|"CANCELED"|"COMPLETE" status;
 };
 
+# Batch request payload containing a list of string input values
 public type BatchInputString record {
+    # Array of string values to process in the batch request
     string[] inputs;
 };
 
+# Standard error object containing details about a failed operation
 public type StandardError record {
+    # Optional sub-classification of the error category
     record {} subCategory?;
+    # Key-value map providing additional contextual details about the error
     record {|string[]...;|} context;
+    # Map of relevant links related to the error
     record {|string...;|} links?;
+    # Unique identifier for the error instance
     string id?;
+    # High-level classification of the error type
     string category;
+    # Human-readable summary of the error
     string message;
+    # List of detailed error objects describing individual failures
     ErrorDetail[] errors?;
+    # HTTP status code or error category identifier
     string status;
 };
 
+# Represents a contact's current subscription status for a given channel and subscription type
 public type PublicStatus record {
+    # Display name of the associated subscription type
     string subscriptionName?;
+    # Communication channel for this status: EMAIL, WHATSAPP, or SMS
     "EMAIL"|"WHATSAPP"|"SMS" channel;
+    # String identifier of the subscriber (e.g., email address or phone number)
     string subscriberIdString;
+    # The legal basis for processing the contact's communication preferences
     "LEGITIMATE_INTEREST_PQL"|"LEGITIMATE_INTEREST_CLIENT"|"PERFORMANCE_OF_CONTRACT"|"CONSENT_WITH_NOTICE"|"NON_GDPR"|"PROCESS_AND_STORE"|"LEGITIMATE_INTEREST_OTHER"? legalBasis?;
+    # The reason the subscription status was successfully updated
     "RESUBSCRIBE_OCCURRED"|"NO_STATUS_CHANGE"|"UNSUBSCRIBE_FROM_ALL_OCCURRED"|"REQUESTED_CHANGE_OCCURRED"? setStatusSuccessReason?;
+    # The source that initiated the subscription status change
     string 'source;
+    # The unique identifier of the subscription type
     int:Signed32 subscriptionId;
+    # A human-readable explanation of the legal basis for processing
     string? legalBasisExplanation?;
+    # The unique identifier of the associated business unit
     int businessUnitId?;
+    # The contact's current subscription status for this subscription type
     "SUBSCRIBED"|"UNSUBSCRIBED"|"NOT_SPECIFIED" status;
+    # The date and time when the subscription status was last updated
     string timestamp;
 };
 
+# Batch response object containing bulk subscription status results, processing metadata, and any errors encountered during the operation
 public type BatchResponsePublicStatusBulkResponseWithErrors record {
+    # The date and time when the bulk batch operation completed
     string completedAt;
+    # The total number of errors encountered during the bulk batch operation
     int:Signed32 numErrors?;
+    # Timestamp when the batch request was received
     string requestedAt?;
+    # Timestamp when batch processing began
     string startedAt;
+    # Map of related resource names to their associated URIs
     record {|string...;|} links?;
+    # Array of subscription status results from the batch operation
     PublicStatusBulkResponse[] results;
+    # Array of standard errors encountered during batch processing
     StandardError[] errors?;
+    # Current processing state of the batch operation
     "PENDING"|"PROCESSING"|"CANCELED"|"COMPLETE" status;
 };
 
+# Represents the batch response for subscription status operations, including processing state, timestamps, and an array of status results
 public type BatchResponsePublicStatusBulkResponse record {
+    # Timestamp when the batch operation completed
     string completedAt;
+    # Timestamp when the batch request was received
     string requestedAt?;
+    # Timestamp when batch processing began
     string startedAt;
+    # Map of related resource names to their associated URIs
     record {|string...;|} links?;
+    # Array of subscription status results from the batch operation
     PublicStatusBulkResponse[] results;
+    # Current processing state of the batch operation
     "PENDING"|"PROCESSING"|"CANCELED"|"COMPLETE" status;
 };
 
+# Detailed error information including a message, status code, field location, category, and contextual data
 public type ErrorDetail record {
     # A specific category that contains more specific detail about the error
     string subCategory?;
@@ -92,23 +141,39 @@ public type ErrorDetail record {
     string message;
 };
 
+# Represents a subscriber's portal-wide or business-unit-wide communication opt status for a specific channel
 public type PublicWideStatus record {
+    # Scope of the status: portal-wide or business-unit-wide
     "PORTAL_WIDE"|"BUSINESS_UNIT_WIDE" wideStatusType;
+    # Unique string identifier for the subscriber
     string subscriberIdString;
+    # Communication channel the status applies to: EMAIL, WHATSAPP, or SMS
     "EMAIL"|"WHATSAPP"|"SMS" channel;
+    # ID of the business unit associated with the status
     int businessUnitId?;
+    # The contact's overall subscription status across all types
     "SUBSCRIBED"|"UNSUBSCRIBED"|"NOT_SPECIFIED" status;
+    # The date and time when the status was last updated
     string timestamp;
 };
 
+# Response object containing the status, timing metadata, and results of a batch subscription definition action
 public type ActionResponseWithResultsSubscriptionDefinition record {
+    # The date and time when the action completed
     string completedAt;
+    # The number of errors encountered during the action
     int:Signed32 numErrors?;
+    # The date and time when the action was requested
     string requestedAt?;
+    # The date and time when the action began processing
     string startedAt;
+    # A map of relevant hyperlinks associated with the action response
     record {|string...;|} links?;
+    # The list of subscription definitions returned by the action
     SubscriptionDefinition[] results;
+    # A list of errors encountered during the action execution
     StandardError[] errors?;
+    # The current processing state of the action
     "PENDING"|"PROCESSING"|"CANCELED"|"COMPLETE" status;
 };
 
@@ -137,21 +202,30 @@ public type PostCommunicationPreferencesV4StatusesSubscriberIdStringUnsubscribeA
     boolean verbose = false;
 };
 
+# Batch response containing bulk opt-out results, processing metadata, and any errors encountered during the operation
 public type BatchResponsePublicBulkOptOutFromAllResponse record {
+    # Timestamp when the batch opt-out operation completed
     string completedAt;
+    # Total number of errors encountered in the batch opt-out operation
     int:Signed32 numErrors?;
+    # Timestamp when the batch opt-out operation was requested
     string requestedAt?;
+    # Timestamp when the batch opt-out operation began processing
     string startedAt;
+    # Map of related resource links associated with the batch response
     record {|string...;|} links?;
+    # List of bulk opt-out results for each processed contact
     PublicBulkOptOutFromAllResponse[] results;
+    # List of standard errors encountered during batch processing
     StandardError[] errors?;
+    # Current processing status of the batch operation
     "PENDING"|"PROCESSING"|"CANCELED"|"COMPLETE" status;
 };
 
-# Provides a set of configurations for controlling the behaviours when communicating with a remote HTTP endpoint.
+# Provides a set of configurations for controlling the behaviours when communicating with a remote HTTP endpoint
 @display {label: "Connection Config"}
 public type ConnectionConfig record {|
-    # Provides Auth configurations needed when communicating with a remote HTTP endpoint.
+    # Provides Auth configurations needed when communicating with a remote HTTP endpoint
     http:BearerTokenConfig|OAuth2RefreshTokenGrantConfig|ApiKeysConfig auth;
     # The HTTP version understood by the client
     http:HttpVersion httpVersion = http:HTTP_2_0;
@@ -188,21 +262,31 @@ public type ConnectionConfig record {|
     # Enables the inbound payload validation functionality which provided by the constraint package. Enabled by default
     boolean validation = true;
     # Enables relaxed data binding on the client side. When enabled, `nil` values are treated as optional, 
-    # and absent fields are handled as `nilable` types. Enabled by default.
+    # and absent fields are handled as `nilable` types. Enabled by default
     boolean laxDataBinding = true;
 |};
 
+# Bulk response containing subscription statuses for a single subscriber
 public type PublicStatusBulkResponse record {
+    # String identifier of the subscriber
     string subscriberIdString;
+    # List of communication preference statuses for the subscriber
     PublicStatus[] statuses;
 };
 
+# Localized translation of a subscription's name and description for a specific language
 public type PublicSubscriptionTranslation record {
+    # Unix timestamp (int32) when the translation was created
     int:Signed32 createdAt;
+    # Localized display name of the subscription
     string name;
+    # Localized description of the subscription
     string description;
+    # ID of the subscription this translation belongs to
     int:Signed32 subscriptionId;
+    # BCP 47 language code for this translation (e.g., 'en', 'fr')
     string languageCode;
+    # Unix timestamp (int32) when the translation was last updated
     int:Signed32 updatedAt;
 };
 
@@ -214,25 +298,41 @@ public type GetCommunicationPreferencesV4DefinitionsQueries record {
     int businessUnitId?;
 };
 
+# Request payload for updating a contact's subscription status on a specific channel
 public type PartialPublicStatusRequest record {
+    # Desired subscription state: SUBSCRIBED, UNSUBSCRIBED, or NOT_SPECIFIED
     "SUBSCRIBED"|"UNSUBSCRIBED"|"NOT_SPECIFIED" statusState;
+    # Communication channel to update: EMAIL, WHATSAPP, or SMS
     "EMAIL"|"WHATSAPP"|"SMS" channel;
+    # GDPR legal basis justifying the subscription status change
     "LEGITIMATE_INTEREST_PQL"|"LEGITIMATE_INTEREST_CLIENT"|"PERFORMANCE_OF_CONTRACT"|"CONSENT_WITH_NOTICE"|"NON_GDPR"|"PROCESS_AND_STORE"|"LEGITIMATE_INTEREST_OTHER" legalBasis?;
+    # Unique identifier of the subscription type to update
     int subscriptionId;
+    # Free-text explanation supporting the specified legal basis
     string legalBasisExplanation?;
 };
 
+# Batch response object containing subscription status results, processing metadata, and any errors encountered during the operation
 public type BatchResponsePublicStatus record {
+    # The date and time when the batch operation completed
     string completedAt;
+    # The total number of errors encountered during the batch operation
     int:Signed32 numErrors?;
+    # The date and time when the batch operation was requested
     string requestedAt?;
+    # The date and time when the batch operation began processing
     string startedAt;
+    # A map of relevant hypermedia links associated with the batch response
     record {|string...;|} links?;
+    # The list of subscription status objects returned by the batch operation
     PublicStatus[] results;
+    # A list of errors encountered for individual records in the batch
     StandardError[] errors?;
+    # The current processing state of the batch operation
     "PENDING"|"PROCESSING"|"CANCELED"|"COMPLETE" status;
 };
 
+# Defines the subscription status update request for a contact, including channel, subscription ID, status state, and optional legal basis details
 public type PublicStatusRequest record {
     # The status of the contact's subscription
     "SUBSCRIBED"|"UNSUBSCRIBED"|"NOT_SPECIFIED" statusState;
@@ -248,19 +348,31 @@ public type PublicStatusRequest record {
     string legalBasisExplanation?;
 };
 
+# Represents a contact's wide-level subscription statuses across all subscription types for a given subscriber
 public type PublicWideStatusBulkResponse record {
+    # Array of wide-level subscription statuses for the contact
     PublicWideStatus[] wideStatuses;
+    # The contact's email address used as the subscriber identifier
     string subscriberIdString;
 };
 
+# Represents the action response for subscription status operations, including processing state, timestamps, error count, and an array of individual status results
 public type ActionResponseWithResultsPublicStatus record {
+    # Timestamp when the action operation completed
     string completedAt;
+    # The total number of errors encountered during processing
     int:Signed32 numErrors?;
+    # Timestamp when the action was requested
     string requestedAt?;
+    # Timestamp when the action processing began
     string startedAt;
+    # Map of relevant hypermedia links associated with the response
     record {|string...;|} links?;
+    # Array of PublicStatus objects returned by the action
     PublicStatus[] results;
+    # List of standard errors encountered during the action
     StandardError[] errors?;
+    # Current processing state of the action: PENDING, PROCESSING, CANCELED, or COMPLETE
     "PENDING"|"PROCESSING"|"CANCELED"|"COMPLETE" status;
 };
 
@@ -272,12 +384,19 @@ public type GetCommunicationPreferencesV4StatusesSubscriberIdStringQueries recor
     int businessUnitId?;
 };
 
+# Batch response containing wide communication status results for multiple subscribers, including processing state and timestamps
 public type BatchResponsePublicWideStatusBulkResponse record {
+    # Timestamp when the batch operation completed
     string completedAt;
+    # Timestamp when the batch operation was requested
     string requestedAt?;
+    # Timestamp when the batch operation processing began
     string startedAt;
+    # Map of relevant hypermedia links associated with the batch response
     record {|string...;|} links?;
+    # Array of wide status bulk response objects returned by the batch operation
     PublicWideStatusBulkResponse[] results;
+    # Current processing state of the batch: PENDING, PROCESSING, CANCELED, or COMPLETE
     "PENDING"|"PROCESSING"|"CANCELED"|"COMPLETE" status;
 };
 
@@ -289,37 +408,60 @@ public type PostCommunicationPreferencesV4StatusesBatchUnsubscribeAllReadQueries
     int businessUnitId?;
 };
 
+# A batch request object containing multiple subscription status update inputs
 public type BatchInputPublicStatusRequest record {
     PublicStatusRequest[] inputs;
 };
 
+# Defines a communication subscription type, including its metadata, state, and available translations
 public type SubscriptionDefinition record {
+    # Indicates whether the subscription is for internal use only
     boolean isInternal;
+    # The date and time when the subscription definition was created
     string createdAt;
+    # Indicates whether this is the default subscription type
     boolean isDefault;
+    # The channel used to deliver communications for this subscription
     string communicationMethod?;
+    # The intended purpose or use case of the subscription type
     string purpose?;
+    # The display name of the subscription definition
     string name;
+    # Human-readable description of the subscription
     string description;
+    # Unique identifier of the subscription definition
     string id;
+    # Indicates whether the subscription is currently active
     boolean isActive;
+    # ID of the business unit associated with the subscription
     int businessUnitId?;
+    # List of localized translations for the subscription definition
     PublicSubscriptionTranslation[] subscriptionTranslations?;
+    # Timestamp of the most recent update to the subscription
     string updatedAt;
 };
 
+# Batch response containing wide-status subscription results, processing metadata, and any errors encountered during the operation
 public type BatchResponsePublicWideStatusBulkResponseWithErrors record {
+    # Timestamp when the batch operation completed
     string completedAt;
+    # Total number of errors encountered in the batch operation
     int:Signed32 numErrors?;
+    # Timestamp when the batch operation was requested
     string requestedAt?;
+    # Timestamp when the batch operation began processing
     string startedAt;
+    # Map of related resource links associated with the batch response
     record {|string...;|} links?;
+    # List of wide-status bulk response results from the batch operation
     PublicWideStatusBulkResponse[] results;
+    # List of errors encountered during the batch operation
     StandardError[] errors?;
+    # Current processing status of the batch operation
     "PENDING"|"PROCESSING"|"CANCELED"|"COMPLETE" status;
 };
 
-# Provides API key configurations needed when communicating with a remote HTTP endpoint.
+# Provides API key configurations needed when communicating with a remote HTTP endpoint
 public type ApiKeysConfig record {|
     string privateAppLegacy;
     string privateApp;
@@ -345,7 +487,10 @@ public type PostCommunicationPreferencesV4StatusesBatchUnsubscribeAllQueries rec
     boolean verbose = false;
 };
 
+# Represents the opt-out result for a single contact in a bulk unsubscribe operation
 public type PublicBulkOptOutFromAllResponse record {
+    # The unique string identifier of the subscriber
     string subscriberIdString;
+    # List of subscription statuses resulting from the opt-out operation
     PublicStatus[] statuses?;
 };

--- a/docs/spec/aligned_ballerina_openapi.json
+++ b/docs/spec/aligned_ballerina_openapi.json
@@ -1,0 +1,1996 @@
+{
+    "openapi": "3.0.1",
+    "info": {
+        "title": "Communication Preferences Subscriptions",
+        "version": "v4",
+        "x-hubspot-product-tier-requirements": {
+            "marketing": "FREE",
+            "sales": "FREE",
+            "service": "FREE",
+            "cms": "FREE"
+        },
+        "x-hubspot-documentation-banner": "NONE",
+        "x-hubspot-api-use-case": "Ensure a contact's opt-in status is updated if they opted out of communications from your business via a service external to HubSpot.",
+        "x-hubspot-related-documentation": [
+            {
+                "name": "Subscriptions preferences guide",
+                "url": "https://developers.hubspot.com/beta-docs/guides/api/marketing/subscriptions"
+            }
+        ],
+        "x-hubspot-introduction": "Use the subscriptions API to programmatically subscribe or unsubscribe contacts from your email subscription types, or unsubscribe a contact from all email communication. These APIs also provide support for business units."
+    },
+    "servers": [
+        {
+            "url": "https://api.hubapi.com/communication-preferences/v4"
+        }
+    ],
+    "tags": [
+        {
+            "name": "Subscription status"
+        },
+        {
+            "name": "Subscription definitions"
+        }
+    ],
+    "paths": {
+        "/statuses/batch/write": {
+            "post": {
+                "tags": [
+                    "Subscription status"
+                ],
+                "summary": "Batch update subscription status",
+                "description": "Update the subscription status for a set of contacts.",
+                "operationId": "post-/communication-preferences/v4/statuses/batch/write",
+                "parameters": [],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/BatchInputPublicStatusRequest"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/BatchResponsePublicStatus"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/Error"
+                    }
+                },
+                "security": [
+                    {
+                        "private_apps": [
+                            "communication_preferences.statuses.batch.write"
+                        ]
+                    },
+                    {
+                        "oauth2": [
+                            "communication_preferences.statuses.batch.write"
+                        ]
+                    }
+                ]
+            }
+        },
+        "/statuses/{subscriberIdString}/unsubscribe-all": {
+            "get": {
+                "tags": [
+                    "Subscription status"
+                ],
+                "summary": "Get contact's unsubscribed status",
+                "description": "Check whether a contact has unsubscribed from all email subscriptions. If a contact has not opted out of all communications, the response `results` array will be empty.",
+                "operationId": "get-/communication-preferences/v4/statuses/{subscriberIdString}/unsubscribe-all",
+                "parameters": [
+                    {
+                        "name": "subscriberIdString",
+                        "in": "path",
+                        "description": "The contact's email address",
+                        "required": true,
+                        "style": "simple",
+                        "explode": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "businessUnitId",
+                        "in": "query",
+                        "description": "If you have the [business unit add-on](https://developers.hubspot.com/beta-docs/guides/api/settings/business-units-api), include this parameter to filter results by business unit ID. The default Account business unit will always use `0`",
+                        "required": false,
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    },
+                    {
+                        "name": "verbose",
+                        "in": "query",
+                        "description": "Set to `true` to include the details of the updated subscription statuses in the response. Not including this parameter will result in an empty response",
+                        "required": false,
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": false
+                        }
+                    },
+                    {
+                        "name": "channel",
+                        "in": "query",
+                        "description": "The channel type for the subscription type. Currently, the only supported channel type is `EMAIL`",
+                        "required": true,
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "EMAIL",
+                                "WHATSAPP",
+                                "SMS"
+                            ]
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ActionResponseWithResultsPublicWideStatus"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/Error"
+                    }
+                },
+                "security": [
+                    {
+                        "private_apps_legacy": [
+                            "communication_preferences.read"
+                        ]
+                    },
+                    {
+                        "oauth2_legacy": [
+                            "communication_preferences.read_write"
+                        ]
+                    },
+                    {
+                        "private_apps_legacy": [
+                            "communication_preferences.read_write"
+                        ]
+                    },
+                    {
+                        "oauth2_legacy": [
+                            "communication_preferences.read"
+                        ]
+                    }
+                ]
+            },
+            "post": {
+                "tags": [
+                    "Subscription status"
+                ],
+                "summary": "Unsubscribe contact from all",
+                "description": "Unsubscribe a contact from all email subscriptions.",
+                "operationId": "post-/communication-preferences/v4/statuses/{subscriberIdString}/unsubscribe-all",
+                "parameters": [
+                    {
+                        "name": "subscriberIdString",
+                        "in": "path",
+                        "description": "The contact's email address",
+                        "required": true,
+                        "style": "simple",
+                        "explode": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "businessUnitId",
+                        "in": "query",
+                        "description": "If you have the [business unit add-on](https://developers.hubspot.com/beta-docs/guides/api/settings/business-units-api), include this parameter to filter results by business unit ID. The default Account business unit will always use `0`",
+                        "required": false,
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    },
+                    {
+                        "name": "verbose",
+                        "in": "query",
+                        "description": "Set to `true` to include the details of the updated subscription statuses in the response. Not including this parameter will result in an empty response",
+                        "required": false,
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": false
+                        }
+                    },
+                    {
+                        "name": "channel",
+                        "in": "query",
+                        "description": "The channel type for the subscription type. Currently, the only supported channel type is `EMAIL`",
+                        "required": true,
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "EMAIL",
+                                "WHATSAPP",
+                                "SMS"
+                            ]
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ActionResponseWithResultsPublicStatus"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/Error"
+                    }
+                },
+                "security": [
+                    {
+                        "oauth2_legacy": [
+                            "communication_preferences.write"
+                        ]
+                    },
+                    {
+                        "oauth2_legacy": [
+                            "communication_preferences.read_write"
+                        ]
+                    },
+                    {
+                        "private_apps_legacy": [
+                            "communication_preferences.write"
+                        ]
+                    },
+                    {
+                        "private_apps_legacy": [
+                            "communication_preferences.read_write"
+                        ]
+                    }
+                ]
+            }
+        },
+        "/statuses/batch/read": {
+            "post": {
+                "tags": [
+                    "Subscription status"
+                ],
+                "summary": "Batch retrieve subscription statuses",
+                "description": "Batch retrieve subscription statuses for a set of contacts.",
+                "operationId": "post-/communication-preferences/v4/statuses/batch/read",
+                "parameters": [
+                    {
+                        "name": "businessUnitId",
+                        "in": "query",
+                        "description": "If you have the [business unit add-on](https://developers.hubspot.com/beta-docs/guides/api/settings/business-units-api), include this parameter to filter results by business unit ID. The default Account business unit will always use `0`",
+                        "required": false,
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    },
+                    {
+                        "name": "channel",
+                        "in": "query",
+                        "description": "The channel type for the subscription type. Currently, the only supported channel type is `EMAIL`",
+                        "required": true,
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "EMAIL",
+                                "WHATSAPP",
+                                "SMS"
+                            ]
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/BatchInputString"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/BatchResponsePublicStatusBulkResponse"
+                                }
+                            }
+                        }
+                    },
+                    "207": {
+                        "description": "multiple statuses",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/BatchResponsePublicStatusBulkResponseWithErrors"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/Error"
+                    }
+                },
+                "security": [
+                    {
+                        "private_apps": [
+                            "communication_preferences.statuses.batch.read"
+                        ]
+                    },
+                    {
+                        "oauth2": [
+                            "communication_preferences.statuses.batch.read"
+                        ]
+                    }
+                ]
+            }
+        },
+        "/statuses/batch/unsubscribe-all": {
+            "post": {
+                "tags": [
+                    "Subscription status"
+                ],
+                "summary": "Batch unsubscribe all contacts",
+                "description": "Unsubscribe a set of contacts from all email subscriptions.",
+                "operationId": "post-/communication-preferences/v4/statuses/batch/unsubscribe-all",
+                "parameters": [
+                    {
+                        "name": "businessUnitId",
+                        "in": "query",
+                        "description": "If you have the [business unit add-on](https://developers.hubspot.com/beta-docs/guides/api/settings/business-units-api), include this parameter to filter results by business unit ID. The default Account business unit will always use `0`",
+                        "required": false,
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    },
+                    {
+                        "name": "verbose",
+                        "in": "query",
+                        "description": "Set to `true` to include the details of the updated subscription statuses in the response. Not including this parameter will result in an empty response",
+                        "required": false,
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": false
+                        }
+                    },
+                    {
+                        "name": "channel",
+                        "in": "query",
+                        "description": "The channel type for the subscription type. Currently, the only supported channel type is `EMAIL`",
+                        "required": true,
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "EMAIL",
+                                "WHATSAPP",
+                                "SMS"
+                            ]
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/BatchInputString"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/BatchResponsePublicBulkOptOutFromAllResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/Error"
+                    }
+                },
+                "security": [
+                    {
+                        "private_apps": [
+                            "communication_preferences.statuses.batch.write"
+                        ]
+                    },
+                    {
+                        "oauth2": [
+                            "communication_preferences.statuses.batch.write"
+                        ]
+                    }
+                ]
+            }
+        },
+        "/definitions": {
+            "get": {
+                "tags": [
+                    "Subscription definitions"
+                ],
+                "summary": "Retrieve all subscription definitions",
+                "description": "Get a list of subscription status definitions from the account.",
+                "operationId": "get-/communication-preferences/v4/definitions",
+                "parameters": [
+                    {
+                        "name": "businessUnitId",
+                        "in": "query",
+                        "description": "If you have the [business unit add-on](https://developers.hubspot.com/beta-docs/guides/api/settings/business-units-api), include this parameter to filter results by business unit ID. The default Account business unit will always use `0`",
+                        "required": false,
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    },
+                    {
+                        "name": "includeTranslations",
+                        "in": "query",
+                        "description": "Set to `true` to return subscription translations associated with each definition",
+                        "required": false,
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "boolean"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ActionResponseWithResultsSubscriptionDefinition"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/Error"
+                    }
+                },
+                "security": [
+                    {
+                        "private_apps_legacy": [
+                            "communication_preferences.read"
+                        ]
+                    },
+                    {
+                        "oauth2_legacy": [
+                            "communication_preferences.read_write"
+                        ]
+                    },
+                    {
+                        "private_apps_legacy": [
+                            "communication_preferences.read_write"
+                        ]
+                    },
+                    {
+                        "oauth2_legacy": [
+                            "communication_preferences.read"
+                        ]
+                    }
+                ]
+            }
+        },
+        "/statuses/batch/unsubscribe-all/read": {
+            "post": {
+                "tags": [
+                    "Subscription status"
+                ],
+                "summary": "Batch get opted-out contacts",
+                "description": "Checks whether a set of contacts have opted out of all communications.",
+                "operationId": "post-/communication-preferences/v4/statuses/batch/unsubscribe-all/read",
+                "parameters": [
+                    {
+                        "name": "businessUnitId",
+                        "in": "query",
+                        "description": "If you have the [business unit add-on](https://developers.hubspot.com/beta-docs/guides/api/settings/business-units-api), include this parameter to filter results by business unit ID. The default Account business unit will always use `0`",
+                        "required": false,
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    },
+                    {
+                        "name": "channel",
+                        "in": "query",
+                        "description": "The channel type for the subscription type. Currently, the only supported channel type is `EMAIL`",
+                        "required": true,
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "EMAIL",
+                                "WHATSAPP",
+                                "SMS"
+                            ]
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/BatchInputString"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/BatchResponsePublicWideStatusBulkResponse"
+                                }
+                            }
+                        }
+                    },
+                    "207": {
+                        "description": "multiple statuses",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/BatchResponsePublicWideStatusBulkResponseWithErrors"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/Error"
+                    }
+                },
+                "security": [
+                    {
+                        "private_apps": [
+                            "communication_preferences.statuses.batch.read"
+                        ]
+                    },
+                    {
+                        "oauth2": [
+                            "communication_preferences.statuses.batch.read"
+                        ]
+                    }
+                ]
+            }
+        },
+        "/statuses/{subscriberIdString}": {
+            "get": {
+                "tags": [
+                    "Subscription status"
+                ],
+                "summary": "Get contact subscription prefs",
+                "description": "Retrieve a contact's current email subscription preferences.",
+                "operationId": "get-/communication-preferences/v4/statuses/{subscriberIdString}",
+                "parameters": [
+                    {
+                        "name": "subscriberIdString",
+                        "in": "path",
+                        "description": "The contact's email address",
+                        "required": true,
+                        "style": "simple",
+                        "explode": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "businessUnitId",
+                        "in": "query",
+                        "description": "If you have the [business unit add-on](https://developers.hubspot.com/beta-docs/guides/api/settings/business-units-api), include this parameter to filter results by business unit ID. The default Account business unit will always use `0`",
+                        "required": false,
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    },
+                    {
+                        "name": "channel",
+                        "in": "query",
+                        "description": "The channel type for the subscription type. Currently, the only supported channel type is `EMAIL`",
+                        "required": true,
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "EMAIL",
+                                "WHATSAPP",
+                                "SMS"
+                            ]
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ActionResponseWithResultsPublicStatus"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/Error"
+                    }
+                },
+                "security": [
+                    {
+                        "private_apps_legacy": [
+                            "communication_preferences.read"
+                        ]
+                    },
+                    {
+                        "oauth2_legacy": [
+                            "communication_preferences.read_write"
+                        ]
+                    },
+                    {
+                        "private_apps_legacy": [
+                            "communication_preferences.read_write"
+                        ]
+                    },
+                    {
+                        "oauth2_legacy": [
+                            "communication_preferences.read"
+                        ]
+                    }
+                ]
+            },
+            "post": {
+                "tags": [
+                    "Subscription status"
+                ],
+                "summary": "Update contact subscription status",
+                "description": "Set the subscription status of a specific contact.",
+                "operationId": "post-/communication-preferences/v4/statuses/{subscriberIdString}",
+                "parameters": [
+                    {
+                        "name": "subscriberIdString",
+                        "in": "path",
+                        "description": "The contact's email address",
+                        "required": true,
+                        "style": "simple",
+                        "explode": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PartialPublicStatusRequest"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ActionResponseWithResultsPublicStatus"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/Error"
+                    }
+                },
+                "security": [
+                    {
+                        "oauth2_legacy": [
+                            "communication_preferences.write"
+                        ]
+                    },
+                    {
+                        "oauth2_legacy": [
+                            "communication_preferences.read_write"
+                        ]
+                    },
+                    {
+                        "private_apps_legacy": [
+                            "communication_preferences.write"
+                        ]
+                    },
+                    {
+                        "private_apps_legacy": [
+                            "communication_preferences.read_write"
+                        ]
+                    }
+                ]
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+            "ActionResponseWithResultsPublicWideStatus": {
+                "required": [
+                    "completedAt",
+                    "results",
+                    "startedAt",
+                    "status"
+                ],
+                "type": "object",
+                "properties": {
+                    "completedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Timestamp when the action completed."
+                    },
+                    "numErrors": {
+                        "type": "integer",
+                        "format": "int32",
+                        "description": "Total number of errors encountered during processing."
+                    },
+                    "requestedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Timestamp when the action was requested."
+                    },
+                    "startedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Timestamp when the action began processing."
+                    },
+                    "links": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "description": "Map of related resource links associated with the response."
+                    },
+                    "results": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/PublicWideStatus"
+                        },
+                        "description": "List of wide-status results returned by the action."
+                    },
+                    "errors": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/StandardError"
+                        },
+                        "description": "List of errors encountered during the action execution."
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": [
+                            "PENDING",
+                            "PROCESSING",
+                            "CANCELED",
+                            "COMPLETE"
+                        ],
+                        "description": "Current processing state of the action: PENDING, PROCESSING, CANCELED, or COMPLETE."
+                    }
+                },
+                "description": "Response object containing async action results with wide-status entries and execution metadata."
+            },
+            "BatchInputString": {
+                "required": [
+                    "inputs"
+                ],
+                "type": "object",
+                "properties": {
+                    "inputs": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "description": "Array of string values to process in the batch request."
+                    }
+                },
+                "description": "Batch request payload containing a list of string input values."
+            },
+            "PublicStatusBulkResponse": {
+                "required": [
+                    "statuses",
+                    "subscriberIdString"
+                ],
+                "type": "object",
+                "properties": {
+                    "subscriberIdString": {
+                        "type": "string",
+                        "description": "String identifier of the subscriber."
+                    },
+                    "statuses": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/PublicStatus"
+                        },
+                        "description": "List of communication preference statuses for the subscriber."
+                    }
+                },
+                "description": "Bulk response containing subscription statuses for a single subscriber."
+            },
+            "StandardError": {
+                "required": [
+                    "category",
+                    "context",
+                    "message",
+                    "status"
+                ],
+                "type": "object",
+                "properties": {
+                    "subCategory": {
+                        "type": "object",
+                        "properties": {},
+                        "description": "Optional sub-classification of the error category."
+                    },
+                    "context": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "description": "Key-value map providing additional contextual details about the error."
+                    },
+                    "links": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "description": "Map of relevant links related to the error."
+                    },
+                    "id": {
+                        "type": "string",
+                        "description": "Unique identifier for the error instance."
+                    },
+                    "category": {
+                        "type": "string",
+                        "description": "High-level classification of the error type."
+                    },
+                    "message": {
+                        "type": "string",
+                        "description": "Human-readable summary of the error."
+                    },
+                    "errors": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/ErrorDetail"
+                        },
+                        "description": "List of detailed error objects describing individual failures."
+                    },
+                    "status": {
+                        "type": "string",
+                        "description": "HTTP status code or error category identifier."
+                    }
+                },
+                "description": "Standard error object containing details about a failed operation."
+            },
+            "PublicSubscriptionTranslation": {
+                "required": [
+                    "createdAt",
+                    "description",
+                    "languageCode",
+                    "name",
+                    "subscriptionId",
+                    "updatedAt"
+                ],
+                "type": "object",
+                "properties": {
+                    "createdAt": {
+                        "type": "integer",
+                        "format": "int32",
+                        "description": "Unix timestamp (int32) when the translation was created."
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "Localized display name of the subscription."
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "Localized description of the subscription."
+                    },
+                    "subscriptionId": {
+                        "type": "integer",
+                        "format": "int32",
+                        "description": "ID of the subscription this translation belongs to."
+                    },
+                    "languageCode": {
+                        "type": "string",
+                        "description": "BCP 47 language code for this translation (e.g., 'en', 'fr')."
+                    },
+                    "updatedAt": {
+                        "type": "integer",
+                        "format": "int32",
+                        "description": "Unix timestamp (int32) when the translation was last updated."
+                    }
+                },
+                "description": "Localized translation of a subscription's name and description for a specific language."
+            },
+            "PartialPublicStatusRequest": {
+                "required": [
+                    "channel",
+                    "statusState",
+                    "subscriptionId"
+                ],
+                "type": "object",
+                "properties": {
+                    "statusState": {
+                        "type": "string",
+                        "enum": [
+                            "SUBSCRIBED",
+                            "UNSUBSCRIBED",
+                            "NOT_SPECIFIED"
+                        ],
+                        "description": "Desired subscription state: SUBSCRIBED, UNSUBSCRIBED, or NOT_SPECIFIED."
+                    },
+                    "channel": {
+                        "type": "string",
+                        "enum": [
+                            "EMAIL",
+                            "WHATSAPP",
+                            "SMS"
+                        ],
+                        "description": "Communication channel to update: EMAIL, WHATSAPP, or SMS."
+                    },
+                    "legalBasis": {
+                        "type": "string",
+                        "enum": [
+                            "LEGITIMATE_INTEREST_PQL",
+                            "LEGITIMATE_INTEREST_CLIENT",
+                            "PERFORMANCE_OF_CONTRACT",
+                            "CONSENT_WITH_NOTICE",
+                            "NON_GDPR",
+                            "PROCESS_AND_STORE",
+                            "LEGITIMATE_INTEREST_OTHER"
+                        ],
+                        "description": "GDPR legal basis justifying the subscription status change."
+                    },
+                    "subscriptionId": {
+                        "type": "integer",
+                        "format": "int64",
+                        "description": "Unique identifier of the subscription type to update."
+                    },
+                    "legalBasisExplanation": {
+                        "type": "string",
+                        "description": "Free-text explanation supporting the specified legal basis."
+                    }
+                },
+                "description": "Request payload for updating a contact's subscription status on a specific channel."
+            },
+            "PublicStatus": {
+                "required": [
+                    "channel",
+                    "source",
+                    "status",
+                    "subscriberIdString",
+                    "subscriptionId",
+                    "timestamp"
+                ],
+                "type": "object",
+                "properties": {
+                    "subscriptionName": {
+                        "type": "string",
+                        "description": "Display name of the associated subscription type."
+                    },
+                    "channel": {
+                        "type": "string",
+                        "enum": [
+                            "EMAIL",
+                            "WHATSAPP",
+                            "SMS"
+                        ],
+                        "description": "Communication channel for this status: EMAIL, WHATSAPP, or SMS."
+                    },
+                    "subscriberIdString": {
+                        "type": "string",
+                        "description": "String identifier of the subscriber (e.g., email address or phone number)."
+                    },
+                    "legalBasis": {
+                        "type": "string",
+                        "nullable": true,
+                        "enum": [
+                            "LEGITIMATE_INTEREST_PQL",
+                            "LEGITIMATE_INTEREST_CLIENT",
+                            "PERFORMANCE_OF_CONTRACT",
+                            "CONSENT_WITH_NOTICE",
+                            "NON_GDPR",
+                            "PROCESS_AND_STORE",
+                            "LEGITIMATE_INTEREST_OTHER"
+                        ],
+                        "description": "The legal basis for processing the contact's communication preferences."
+                    },
+                    "setStatusSuccessReason": {
+                        "type": "string",
+                        "nullable": true,
+                        "enum": [
+                            "RESUBSCRIBE_OCCURRED",
+                            "NO_STATUS_CHANGE",
+                            "UNSUBSCRIBE_FROM_ALL_OCCURRED",
+                            "REQUESTED_CHANGE_OCCURRED"
+                        ],
+                        "description": "The reason the subscription status was successfully updated."
+                    },
+                    "source": {
+                        "type": "string",
+                        "description": "The source that initiated the subscription status change."
+                    },
+                    "subscriptionId": {
+                        "type": "integer",
+                        "format": "int32",
+                        "description": "The unique identifier of the subscription type."
+                    },
+                    "legalBasisExplanation": {
+                        "type": "string",
+                        "nullable": true,
+                        "description": "A human-readable explanation of the legal basis for processing."
+                    },
+                    "businessUnitId": {
+                        "type": "integer",
+                        "format": "int64",
+                        "description": "The unique identifier of the associated business unit."
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": [
+                            "SUBSCRIBED",
+                            "UNSUBSCRIBED",
+                            "NOT_SPECIFIED"
+                        ],
+                        "description": "The contact's current subscription status for this subscription type."
+                    },
+                    "timestamp": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "The date and time when the subscription status was last updated."
+                    }
+                },
+                "description": "Represents a contact's current subscription status for a given channel and subscription type."
+            },
+            "BatchResponsePublicStatus": {
+                "required": [
+                    "completedAt",
+                    "results",
+                    "startedAt",
+                    "status"
+                ],
+                "type": "object",
+                "properties": {
+                    "completedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "The date and time when the batch operation completed."
+                    },
+                    "numErrors": {
+                        "type": "integer",
+                        "format": "int32",
+                        "description": "The total number of errors encountered during the batch operation."
+                    },
+                    "requestedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "The date and time when the batch operation was requested."
+                    },
+                    "startedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "The date and time when the batch operation began processing."
+                    },
+                    "links": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "description": "A map of relevant hypermedia links associated with the batch response."
+                    },
+                    "results": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/PublicStatus"
+                        },
+                        "description": "The list of subscription status objects returned by the batch operation."
+                    },
+                    "errors": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/StandardError"
+                        },
+                        "description": "A list of errors encountered for individual records in the batch."
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": [
+                            "PENDING",
+                            "PROCESSING",
+                            "CANCELED",
+                            "COMPLETE"
+                        ],
+                        "description": "The current processing state of the batch operation."
+                    }
+                },
+                "description": "Batch response object containing subscription status results, processing metadata, and any errors encountered during the operation."
+            },
+            "BatchResponsePublicStatusBulkResponseWithErrors": {
+                "required": [
+                    "completedAt",
+                    "results",
+                    "startedAt",
+                    "status"
+                ],
+                "type": "object",
+                "properties": {
+                    "completedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "The date and time when the bulk batch operation completed."
+                    },
+                    "numErrors": {
+                        "type": "integer",
+                        "format": "int32",
+                        "description": "The total number of errors encountered during the bulk batch operation."
+                    },
+                    "requestedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Timestamp when the batch request was received."
+                    },
+                    "startedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Timestamp when batch processing began."
+                    },
+                    "links": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "description": "Map of related resource names to their associated URIs."
+                    },
+                    "results": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/PublicStatusBulkResponse"
+                        },
+                        "description": "Array of subscription status results from the batch operation."
+                    },
+                    "errors": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/StandardError"
+                        },
+                        "description": "Array of standard errors encountered during batch processing."
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": [
+                            "PENDING",
+                            "PROCESSING",
+                            "CANCELED",
+                            "COMPLETE"
+                        ],
+                        "description": "Current processing state of the batch operation."
+                    }
+                },
+                "description": "Batch response object containing bulk subscription status results, processing metadata, and any errors encountered during the operation."
+            },
+            "Error": {
+                "required": [
+                    "category",
+                    "correlationId",
+                    "message"
+                ],
+                "type": "object",
+                "properties": {
+                    "subCategory": {
+                        "type": "string",
+                        "description": "A specific category that contains more specific detail about the error"
+                    },
+                    "context": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "description": "Context about the error condition",
+                        "example": {
+                            "missingScopes": [
+                                "scope1",
+                                "scope2"
+                            ],
+                            "invalidPropertyName": [
+                                "propertyValue"
+                            ]
+                        }
+                    },
+                    "correlationId": {
+                        "type": "string",
+                        "description": "A unique identifier for the request. Include this value with any error reports or support tickets",
+                        "format": "uuid",
+                        "example": "aeb5f871-7f07-4993-9211-075dc63e7cbf"
+                    },
+                    "links": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "description": "A map of link names to associated URIs containing documentation about the error or recommended remediation steps"
+                    },
+                    "message": {
+                        "type": "string",
+                        "description": "A human readable message describing the error along with remediation steps where appropriate",
+                        "example": "An error occurred"
+                    },
+                    "category": {
+                        "type": "string",
+                        "description": "The error category"
+                    },
+                    "errors": {
+                        "type": "array",
+                        "description": "further information about the error",
+                        "items": {
+                            "$ref": "#/components/schemas/ErrorDetail"
+                        }
+                    }
+                },
+                "example": {
+                    "message": "Invalid input (details will vary based on the error)",
+                    "correlationId": "aeb5f871-7f07-4993-9211-075dc63e7cbf",
+                    "category": "VALIDATION_ERROR",
+                    "links": {
+                        "knowledge-base": "https://www.hubspot.com/products/service/knowledge-base"
+                    }
+                },
+                "description": "Represents an API error response, including a message, category, correlation ID, and optional context details for diagnostics and remediation."
+            },
+            "PublicStatusRequest": {
+                "required": [
+                    "channel",
+                    "statusState",
+                    "subscriberIdString",
+                    "subscriptionId"
+                ],
+                "type": "object",
+                "properties": {
+                    "statusState": {
+                        "type": "string",
+                        "description": "The status of the contact's subscription",
+                        "enum": [
+                            "SUBSCRIBED",
+                            "UNSUBSCRIBED",
+                            "NOT_SPECIFIED"
+                        ]
+                    },
+                    "channel": {
+                        "type": "string",
+                        "description": "The type of communication channel. Currently, only `EMAIL` is supported",
+                        "enum": [
+                            "EMAIL",
+                            "WHATSAPP",
+                            "SMS"
+                        ]
+                    },
+                    "subscriberIdString": {
+                        "type": "string",
+                        "description": "The contact's email address"
+                    },
+                    "legalBasis": {
+                        "type": "string",
+                        "description": "The legal basis for communication",
+                        "enum": [
+                            "LEGITIMATE_INTEREST_PQL",
+                            "LEGITIMATE_INTEREST_CLIENT",
+                            "PERFORMANCE_OF_CONTRACT",
+                            "CONSENT_WITH_NOTICE",
+                            "NON_GDPR",
+                            "PROCESS_AND_STORE",
+                            "LEGITIMATE_INTEREST_OTHER"
+                        ]
+                    },
+                    "subscriptionId": {
+                        "type": "integer",
+                        "description": "The ID of the subscription to update",
+                        "format": "int32"
+                    },
+                    "legalBasisExplanation": {
+                        "type": "string",
+                        "description": "The explanation for the legal basis"
+                    }
+                },
+                "description": "Defines the subscription status update request for a contact, including channel, subscription ID, status state, and optional legal basis details."
+            },
+            "PublicWideStatusBulkResponse": {
+                "required": [
+                    "subscriberIdString",
+                    "wideStatuses"
+                ],
+                "type": "object",
+                "properties": {
+                    "wideStatuses": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/PublicWideStatus"
+                        },
+                        "description": "Array of wide-level subscription statuses for the contact."
+                    },
+                    "subscriberIdString": {
+                        "type": "string",
+                        "description": "The contact's email address used as the subscriber identifier."
+                    }
+                },
+                "description": "Represents a contact's wide-level subscription statuses across all subscription types for a given subscriber."
+            },
+            "BatchResponsePublicStatusBulkResponse": {
+                "required": [
+                    "completedAt",
+                    "results",
+                    "startedAt",
+                    "status"
+                ],
+                "type": "object",
+                "properties": {
+                    "completedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Timestamp when the batch operation completed."
+                    },
+                    "requestedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Timestamp when the batch request was received."
+                    },
+                    "startedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Timestamp when batch processing began."
+                    },
+                    "links": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "description": "Map of related resource names to their associated URIs."
+                    },
+                    "results": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/PublicStatusBulkResponse"
+                        },
+                        "description": "Array of subscription status results from the batch operation."
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": [
+                            "PENDING",
+                            "PROCESSING",
+                            "CANCELED",
+                            "COMPLETE"
+                        ],
+                        "description": "Current processing state of the batch operation."
+                    }
+                },
+                "description": "Represents the batch response for subscription status operations, including processing state, timestamps, and an array of status results."
+            },
+            "ActionResponseWithResultsPublicStatus": {
+                "required": [
+                    "completedAt",
+                    "results",
+                    "startedAt",
+                    "status"
+                ],
+                "type": "object",
+                "properties": {
+                    "completedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Timestamp when the action operation completed."
+                    },
+                    "numErrors": {
+                        "type": "integer",
+                        "format": "int32",
+                        "description": "The total number of errors encountered during processing."
+                    },
+                    "requestedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Timestamp when the action was requested."
+                    },
+                    "startedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Timestamp when the action processing began."
+                    },
+                    "links": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "description": "Map of relevant hypermedia links associated with the response."
+                    },
+                    "results": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/PublicStatus"
+                        },
+                        "description": "Array of PublicStatus objects returned by the action."
+                    },
+                    "errors": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/StandardError"
+                        },
+                        "description": "List of standard errors encountered during the action."
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": [
+                            "PENDING",
+                            "PROCESSING",
+                            "CANCELED",
+                            "COMPLETE"
+                        ],
+                        "description": "Current processing state of the action: PENDING, PROCESSING, CANCELED, or COMPLETE."
+                    }
+                },
+                "description": "Represents the action response for subscription status operations, including processing state, timestamps, error count, and an array of individual status results."
+            },
+            "BatchResponsePublicWideStatusBulkResponse": {
+                "required": [
+                    "completedAt",
+                    "results",
+                    "startedAt",
+                    "status"
+                ],
+                "type": "object",
+                "properties": {
+                    "completedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Timestamp when the batch operation completed."
+                    },
+                    "requestedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Timestamp when the batch operation was requested."
+                    },
+                    "startedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Timestamp when the batch operation processing began."
+                    },
+                    "links": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "description": "Map of relevant hypermedia links associated with the batch response."
+                    },
+                    "results": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/PublicWideStatusBulkResponse"
+                        },
+                        "description": "Array of wide status bulk response objects returned by the batch operation."
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": [
+                            "PENDING",
+                            "PROCESSING",
+                            "CANCELED",
+                            "COMPLETE"
+                        ],
+                        "description": "Current processing state of the batch: PENDING, PROCESSING, CANCELED, or COMPLETE."
+                    }
+                },
+                "description": "Batch response containing wide communication status results for multiple subscribers, including processing state and timestamps."
+            },
+            "ErrorDetail": {
+                "required": [
+                    "message"
+                ],
+                "type": "object",
+                "properties": {
+                    "subCategory": {
+                        "type": "string",
+                        "description": "A specific category that contains more specific detail about the error"
+                    },
+                    "code": {
+                        "type": "string",
+                        "description": "The status code associated with the error detail"
+                    },
+                    "in": {
+                        "type": "string",
+                        "description": "The name of the field or parameter in which the error was found"
+                    },
+                    "context": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "description": "Context about the error condition",
+                        "example": {
+                            "missingScopes": [
+                                "scope1",
+                                "scope2"
+                            ]
+                        }
+                    },
+                    "message": {
+                        "type": "string",
+                        "description": "A human readable message describing the error along with remediation steps where appropriate"
+                    }
+                },
+                "description": "Detailed error information including a message, status code, field location, category, and contextual data."
+            },
+            "PublicWideStatus": {
+                "required": [
+                    "channel",
+                    "status",
+                    "subscriberIdString",
+                    "timestamp",
+                    "wideStatusType"
+                ],
+                "type": "object",
+                "properties": {
+                    "wideStatusType": {
+                        "type": "string",
+                        "enum": [
+                            "PORTAL_WIDE",
+                            "BUSINESS_UNIT_WIDE"
+                        ],
+                        "description": "Scope of the status: portal-wide or business-unit-wide."
+                    },
+                    "subscriberIdString": {
+                        "type": "string",
+                        "description": "Unique string identifier for the subscriber."
+                    },
+                    "channel": {
+                        "type": "string",
+                        "enum": [
+                            "EMAIL",
+                            "WHATSAPP",
+                            "SMS"
+                        ],
+                        "description": "Communication channel the status applies to: EMAIL, WHATSAPP, or SMS."
+                    },
+                    "businessUnitId": {
+                        "type": "integer",
+                        "format": "int64",
+                        "description": "ID of the business unit associated with the status."
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": [
+                            "SUBSCRIBED",
+                            "UNSUBSCRIBED",
+                            "NOT_SPECIFIED"
+                        ],
+                        "description": "The contact's overall subscription status across all types."
+                    },
+                    "timestamp": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "The date and time when the status was last updated."
+                    }
+                },
+                "description": "Represents a subscriber's portal-wide or business-unit-wide communication opt status for a specific channel."
+            },
+            "ActionResponseWithResultsSubscriptionDefinition": {
+                "required": [
+                    "completedAt",
+                    "results",
+                    "startedAt",
+                    "status"
+                ],
+                "type": "object",
+                "properties": {
+                    "completedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "The date and time when the action completed."
+                    },
+                    "numErrors": {
+                        "type": "integer",
+                        "format": "int32",
+                        "description": "The number of errors encountered during the action."
+                    },
+                    "requestedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "The date and time when the action was requested."
+                    },
+                    "startedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "The date and time when the action began processing."
+                    },
+                    "links": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "description": "A map of relevant hyperlinks associated with the action response."
+                    },
+                    "results": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/SubscriptionDefinition"
+                        },
+                        "description": "The list of subscription definitions returned by the action."
+                    },
+                    "errors": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/StandardError"
+                        },
+                        "description": "A list of errors encountered during the action execution."
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": [
+                            "PENDING",
+                            "PROCESSING",
+                            "CANCELED",
+                            "COMPLETE"
+                        ],
+                        "description": "The current processing state of the action."
+                    }
+                },
+                "description": "Response object containing the status, timing metadata, and results of a batch subscription definition action."
+            },
+            "BatchInputPublicStatusRequest": {
+                "required": [
+                    "inputs"
+                ],
+                "type": "object",
+                "properties": {
+                    "inputs": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/PublicStatusRequest"
+                        }
+                    }
+                },
+                "description": "A batch request object containing multiple subscription status update inputs."
+            },
+            "SubscriptionDefinition": {
+                "required": [
+                    "createdAt",
+                    "description",
+                    "id",
+                    "isActive",
+                    "isDefault",
+                    "isInternal",
+                    "name",
+                    "updatedAt"
+                ],
+                "type": "object",
+                "properties": {
+                    "isInternal": {
+                        "type": "boolean",
+                        "description": "Indicates whether the subscription is for internal use only."
+                    },
+                    "createdAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "The date and time when the subscription definition was created."
+                    },
+                    "isDefault": {
+                        "type": "boolean",
+                        "description": "Indicates whether this is the default subscription type."
+                    },
+                    "communicationMethod": {
+                        "type": "string",
+                        "description": "The channel used to deliver communications for this subscription."
+                    },
+                    "purpose": {
+                        "type": "string",
+                        "description": "The intended purpose or use case of the subscription type."
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "The display name of the subscription definition."
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "Human-readable description of the subscription."
+                    },
+                    "id": {
+                        "type": "string",
+                        "description": "Unique identifier of the subscription definition."
+                    },
+                    "isActive": {
+                        "type": "boolean",
+                        "description": "Indicates whether the subscription is currently active."
+                    },
+                    "businessUnitId": {
+                        "type": "integer",
+                        "format": "int64",
+                        "description": "ID of the business unit associated with the subscription."
+                    },
+                    "subscriptionTranslations": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/PublicSubscriptionTranslation"
+                        },
+                        "description": "List of localized translations for the subscription definition."
+                    },
+                    "updatedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Timestamp of the most recent update to the subscription."
+                    }
+                },
+                "description": "Defines a communication subscription type, including its metadata, state, and available translations."
+            },
+            "BatchResponsePublicWideStatusBulkResponseWithErrors": {
+                "required": [
+                    "completedAt",
+                    "results",
+                    "startedAt",
+                    "status"
+                ],
+                "type": "object",
+                "properties": {
+                    "completedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Timestamp when the batch operation completed."
+                    },
+                    "numErrors": {
+                        "type": "integer",
+                        "format": "int32",
+                        "description": "Total number of errors encountered in the batch operation."
+                    },
+                    "requestedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Timestamp when the batch operation was requested."
+                    },
+                    "startedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Timestamp when the batch operation began processing."
+                    },
+                    "links": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "description": "Map of related resource links associated with the batch response."
+                    },
+                    "results": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/PublicWideStatusBulkResponse"
+                        },
+                        "description": "List of wide-status bulk response results from the batch operation."
+                    },
+                    "errors": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/StandardError"
+                        },
+                        "description": "List of errors encountered during the batch operation."
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": [
+                            "PENDING",
+                            "PROCESSING",
+                            "CANCELED",
+                            "COMPLETE"
+                        ],
+                        "description": "Current processing status of the batch operation."
+                    }
+                },
+                "description": "Batch response containing wide-status subscription results, processing metadata, and any errors encountered during the operation."
+            },
+            "BatchResponsePublicBulkOptOutFromAllResponse": {
+                "required": [
+                    "completedAt",
+                    "results",
+                    "startedAt",
+                    "status"
+                ],
+                "type": "object",
+                "properties": {
+                    "completedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Timestamp when the batch opt-out operation completed."
+                    },
+                    "numErrors": {
+                        "type": "integer",
+                        "format": "int32",
+                        "description": "Total number of errors encountered in the batch opt-out operation."
+                    },
+                    "requestedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Timestamp when the batch opt-out operation was requested."
+                    },
+                    "startedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Timestamp when the batch opt-out operation began processing."
+                    },
+                    "links": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "description": "Map of related resource links associated with the batch response."
+                    },
+                    "results": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/PublicBulkOptOutFromAllResponse"
+                        },
+                        "description": "List of bulk opt-out results for each processed contact."
+                    },
+                    "errors": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/StandardError"
+                        },
+                        "description": "List of standard errors encountered during batch processing."
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": [
+                            "PENDING",
+                            "PROCESSING",
+                            "CANCELED",
+                            "COMPLETE"
+                        ],
+                        "description": "Current processing status of the batch operation."
+                    }
+                },
+                "description": "Batch response containing bulk opt-out results, processing metadata, and any errors encountered during the operation."
+            },
+            "PublicBulkOptOutFromAllResponse": {
+                "required": [
+                    "subscriberIdString"
+                ],
+                "type": "object",
+                "properties": {
+                    "subscriberIdString": {
+                        "type": "string",
+                        "description": "The unique string identifier of the subscriber."
+                    },
+                    "statuses": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/PublicStatus"
+                        },
+                        "description": "List of subscription statuses resulting from the opt-out operation."
+                    }
+                },
+                "description": "Represents the opt-out result for a single contact in a bulk unsubscribe operation."
+            }
+        },
+        "responses": {
+            "Error": {
+                "description": "An error occurred.",
+                "content": {
+                    "*/*": {
+                        "schema": {
+                            "$ref": "#/components/schemas/Error"
+                        }
+                    }
+                }
+            }
+        },
+        "securitySchemes": {
+            "oauth2_legacy": {
+                "type": "oauth2",
+                "flows": {
+                    "authorizationCode": {
+                        "authorizationUrl": "https://app.hubspot.com/oauth/authorize",
+                        "tokenUrl": "https://api.hubapi.com/oauth/v1/token",
+                        "scopes": {
+                            "communication_preferences.read_write": "Update contact subscription preferences",
+                            "communication_preferences.read": "Read contact subscription preferences",
+                            "communication_preferences.write": "Update contact subscription preferences"
+                        }
+                    }
+                }
+            },
+            "oauth2": {
+                "type": "oauth2",
+                "flows": {
+                    "authorizationCode": {
+                        "authorizationUrl": "https://app.hubspot.com/oauth/authorize",
+                        "tokenUrl": "https://api.hubapi.com/oauth/v1/token",
+                        "scopes": {
+                            "communication_preferences.statuses.batch.read": "Batch read contact subscription preferences",
+                            "communication_preferences.statuses.batch.write": "Batch update contact subscription preferences"
+                        }
+                    }
+                }
+            },
+            "private_apps_legacy": {
+                "type": "apiKey",
+                "name": "private-app-legacy",
+                "in": "header",
+                "x-ballerina-name": "privateAppLegacy"
+            },
+            "private_apps": {
+                "type": "apiKey",
+                "name": "private-app",
+                "in": "header",
+                "x-ballerina-name": "privateApp"
+            }
+        }
+    }
+}

--- a/docs/spec/flattened_openapi.json
+++ b/docs/spec/flattened_openapi.json
@@ -1,0 +1,1456 @@
+{
+  "openapi" : "3.0.1",
+  "info" : {
+    "title" : "Communication Preferences Subscriptions",
+    "version" : "v4",
+    "x-hubspot-product-tier-requirements" : {
+      "marketing" : "FREE",
+      "sales" : "FREE",
+      "service" : "FREE",
+      "cms" : "FREE"
+    },
+    "x-hubspot-documentation-banner" : "NONE",
+    "x-hubspot-api-use-case" : "Ensure a contact's opt-in status is updated if they opted out of communications from your business via a service external to HubSpot.",
+    "x-hubspot-related-documentation" : [ {
+      "name" : "Subscriptions preferences guide",
+      "url" : "https://developers.hubspot.com/beta-docs/guides/api/marketing/subscriptions"
+    } ],
+    "x-hubspot-introduction" : "Use the subscriptions API to programmatically subscribe or unsubscribe contacts from your email subscription types, or unsubscribe a contact from all email communication. These APIs also provide support for business units."
+  },
+  "servers" : [ {
+    "url" : "https://api.hubapi.com/communication-preferences/v4"
+  } ],
+  "tags" : [ {
+    "name" : "Subscription status"
+  }, {
+    "name" : "Subscription definitions"
+  } ],
+  "paths" : {
+    "/statuses/batch/write" : {
+      "post" : {
+        "tags" : [ "Subscription status" ],
+        "summary" : "Batch update subscription status",
+        "description" : "Update the subscription status for a set of contacts.",
+        "operationId" : "post-/communication-preferences/v4/statuses/batch/write",
+        "parameters" : [ ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/BatchInputPublicStatusRequest"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/BatchResponsePublicStatus"
+                }
+              }
+            }
+          },
+          "default" : {
+            "$ref" : "#/components/responses/Error"
+          }
+        },
+        "security" : [ {
+          "private_apps" : [ "communication_preferences.statuses.batch.write" ]
+        }, {
+          "oauth2" : [ "communication_preferences.statuses.batch.write" ]
+        } ]
+      }
+    },
+    "/statuses/{subscriberIdString}/unsubscribe-all" : {
+      "get" : {
+        "tags" : [ "Subscription status" ],
+        "summary" : "Retrieve a contact's unsubscribed status",
+        "description" : "Check whether a contact has unsubscribed from all email subscriptions. If a contact has not opted out of all communications, the response `results` array will be empty.",
+        "operationId" : "get-/communication-preferences/v4/statuses/{subscriberIdString}/unsubscribe-all",
+        "parameters" : [ {
+          "name" : "subscriberIdString",
+          "in" : "path",
+          "description" : "The contact's email address",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "businessUnitId",
+          "in" : "query",
+          "description" : "If you have the [business unit add-on](https://developers.hubspot.com/beta-docs/guides/api/settings/business-units-api), include this parameter to filter results by business unit ID. The default Account business unit will always use `0`",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "integer",
+            "format" : "int64"
+          }
+        }, {
+          "name" : "verbose",
+          "in" : "query",
+          "description" : "Set to `true` to include the details of the updated subscription statuses in the response. Not including this parameter will result in an empty response",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "boolean",
+            "default" : false
+          }
+        }, {
+          "name" : "channel",
+          "in" : "query",
+          "description" : "The channel type for the subscription type. Currently, the only supported channel type is `EMAIL`",
+          "required" : true,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "string",
+            "enum" : [ "EMAIL", "WHATSAPP", "SMS" ]
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ActionResponseWithResultsPublicWideStatus"
+                }
+              }
+            }
+          },
+          "default" : {
+            "$ref" : "#/components/responses/Error"
+          }
+        },
+        "security" : [ {
+          "private_apps_legacy" : [ "communication_preferences.read" ]
+        }, {
+          "oauth2_legacy" : [ "communication_preferences.read_write" ]
+        }, {
+          "private_apps_legacy" : [ "communication_preferences.read_write" ]
+        }, {
+          "oauth2_legacy" : [ "communication_preferences.read" ]
+        } ]
+      },
+      "post" : {
+        "tags" : [ "Subscription status" ],
+        "summary" : "Unsubscribe a contact from all subscriptions",
+        "description" : "Unsubscribe a contact from all email subscriptions.",
+        "operationId" : "post-/communication-preferences/v4/statuses/{subscriberIdString}/unsubscribe-all",
+        "parameters" : [ {
+          "name" : "subscriberIdString",
+          "in" : "path",
+          "description" : "The contact's email address",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "businessUnitId",
+          "in" : "query",
+          "description" : "If you have the [business unit add-on](https://developers.hubspot.com/beta-docs/guides/api/settings/business-units-api), include this parameter to filter results by business unit ID. The default Account business unit will always use `0`",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "integer",
+            "format" : "int64"
+          }
+        }, {
+          "name" : "verbose",
+          "in" : "query",
+          "description" : "Set to `true` to include the details of the updated subscription statuses in the response. Not including this parameter will result in an empty response",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "boolean",
+            "default" : false
+          }
+        }, {
+          "name" : "channel",
+          "in" : "query",
+          "description" : "The channel type for the subscription type. Currently, the only supported channel type is `EMAIL`",
+          "required" : true,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "string",
+            "enum" : [ "EMAIL", "WHATSAPP", "SMS" ]
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ActionResponseWithResultsPublicStatus"
+                }
+              }
+            }
+          },
+          "default" : {
+            "$ref" : "#/components/responses/Error"
+          }
+        },
+        "security" : [ {
+          "oauth2_legacy" : [ "communication_preferences.write" ]
+        }, {
+          "oauth2_legacy" : [ "communication_preferences.read_write" ]
+        }, {
+          "private_apps_legacy" : [ "communication_preferences.write" ]
+        }, {
+          "private_apps_legacy" : [ "communication_preferences.read_write" ]
+        } ]
+      }
+    },
+    "/statuses/batch/read" : {
+      "post" : {
+        "tags" : [ "Subscription status" ],
+        "summary" : "Batch retrieve subscription statuses",
+        "description" : "Batch retrieve subscription statuses for a set of contacts.",
+        "operationId" : "post-/communication-preferences/v4/statuses/batch/read",
+        "parameters" : [ {
+          "name" : "businessUnitId",
+          "in" : "query",
+          "description" : "If you have the [business unit add-on](https://developers.hubspot.com/beta-docs/guides/api/settings/business-units-api), include this parameter to filter results by business unit ID. The default Account business unit will always use `0`",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "integer",
+            "format" : "int64"
+          }
+        }, {
+          "name" : "channel",
+          "in" : "query",
+          "description" : "The channel type for the subscription type. Currently, the only supported channel type is `EMAIL`",
+          "required" : true,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "string",
+            "enum" : [ "EMAIL", "WHATSAPP", "SMS" ]
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/BatchInputString"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/BatchResponsePublicStatusBulkResponse"
+                }
+              }
+            }
+          },
+          "207" : {
+            "description" : "multiple statuses",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/BatchResponsePublicStatusBulkResponseWithErrors"
+                }
+              }
+            }
+          },
+          "default" : {
+            "$ref" : "#/components/responses/Error"
+          }
+        },
+        "security" : [ {
+          "private_apps" : [ "communication_preferences.statuses.batch.read" ]
+        }, {
+          "oauth2" : [ "communication_preferences.statuses.batch.read" ]
+        } ]
+      }
+    },
+    "/statuses/batch/unsubscribe-all" : {
+      "post" : {
+        "tags" : [ "Subscription status" ],
+        "summary" : "Batch unsubscribe contacts from all subscriptions",
+        "description" : "Unsubscribe a set of contacts from all email subscriptions.",
+        "operationId" : "post-/communication-preferences/v4/statuses/batch/unsubscribe-all",
+        "parameters" : [ {
+          "name" : "businessUnitId",
+          "in" : "query",
+          "description" : "If you have the [business unit add-on](https://developers.hubspot.com/beta-docs/guides/api/settings/business-units-api), include this parameter to filter results by business unit ID. The default Account business unit will always use `0`",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "integer",
+            "format" : "int64"
+          }
+        }, {
+          "name" : "verbose",
+          "in" : "query",
+          "description" : "Set to `true` to include the details of the updated subscription statuses in the response. Not including this parameter will result in an empty response",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "boolean",
+            "default" : false
+          }
+        }, {
+          "name" : "channel",
+          "in" : "query",
+          "description" : "The channel type for the subscription type. Currently, the only supported channel type is `EMAIL`",
+          "required" : true,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "string",
+            "enum" : [ "EMAIL", "WHATSAPP", "SMS" ]
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/BatchInputString"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/BatchResponsePublicBulkOptOutFromAllResponse"
+                }
+              }
+            }
+          },
+          "default" : {
+            "$ref" : "#/components/responses/Error"
+          }
+        },
+        "security" : [ {
+          "private_apps" : [ "communication_preferences.statuses.batch.write" ]
+        }, {
+          "oauth2" : [ "communication_preferences.statuses.batch.write" ]
+        } ]
+      }
+    },
+    "/definitions" : {
+      "get" : {
+        "tags" : [ "Subscription definitions" ],
+        "summary" : "Retrieve all subscription status definitions",
+        "description" : "Get a list of subscription status definitions from the account.",
+        "operationId" : "get-/communication-preferences/v4/definitions",
+        "parameters" : [ {
+          "name" : "businessUnitId",
+          "in" : "query",
+          "description" : "If you have the [business unit add-on](https://developers.hubspot.com/beta-docs/guides/api/settings/business-units-api), include this parameter to filter results by business unit ID. The default Account business unit will always use `0`",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "integer",
+            "format" : "int64"
+          }
+        }, {
+          "name" : "includeTranslations",
+          "in" : "query",
+          "description" : "Set to `true` to return subscription translations associated with each definition",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "boolean"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ActionResponseWithResultsSubscriptionDefinition"
+                }
+              }
+            }
+          },
+          "default" : {
+            "$ref" : "#/components/responses/Error"
+          }
+        },
+        "security" : [ {
+          "private_apps_legacy" : [ "communication_preferences.read" ]
+        }, {
+          "oauth2_legacy" : [ "communication_preferences.read_write" ]
+        }, {
+          "private_apps_legacy" : [ "communication_preferences.read_write" ]
+        }, {
+          "oauth2_legacy" : [ "communication_preferences.read" ]
+        } ]
+      }
+    },
+    "/statuses/batch/unsubscribe-all/read" : {
+      "post" : {
+        "tags" : [ "Subscription status" ],
+        "summary" : "Batch retrieve contacts who have opted out of all communications",
+        "description" : "Checks whether a set of contacts have opted out of all communications.",
+        "operationId" : "post-/communication-preferences/v4/statuses/batch/unsubscribe-all/read",
+        "parameters" : [ {
+          "name" : "businessUnitId",
+          "in" : "query",
+          "description" : "If you have the [business unit add-on](https://developers.hubspot.com/beta-docs/guides/api/settings/business-units-api), include this parameter to filter results by business unit ID. The default Account business unit will always use `0`",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "integer",
+            "format" : "int64"
+          }
+        }, {
+          "name" : "channel",
+          "in" : "query",
+          "description" : "The channel type for the subscription type. Currently, the only supported channel type is `EMAIL`",
+          "required" : true,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "string",
+            "enum" : [ "EMAIL", "WHATSAPP", "SMS" ]
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/BatchInputString"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/BatchResponsePublicWideStatusBulkResponse"
+                }
+              }
+            }
+          },
+          "207" : {
+            "description" : "multiple statuses",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/BatchResponsePublicWideStatusBulkResponseWithErrors"
+                }
+              }
+            }
+          },
+          "default" : {
+            "$ref" : "#/components/responses/Error"
+          }
+        },
+        "security" : [ {
+          "private_apps" : [ "communication_preferences.statuses.batch.read" ]
+        }, {
+          "oauth2" : [ "communication_preferences.statuses.batch.read" ]
+        } ]
+      }
+    },
+    "/statuses/{subscriberIdString}" : {
+      "get" : {
+        "tags" : [ "Subscription status" ],
+        "summary" : "Get subscription preferences for a specific contact",
+        "description" : "Retrieve a contact's current email subscription preferences.",
+        "operationId" : "get-/communication-preferences/v4/statuses/{subscriberIdString}",
+        "parameters" : [ {
+          "name" : "subscriberIdString",
+          "in" : "path",
+          "description" : "The contact's email address",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "businessUnitId",
+          "in" : "query",
+          "description" : "If you have the [business unit add-on](https://developers.hubspot.com/beta-docs/guides/api/settings/business-units-api), include this parameter to filter results by business unit ID. The default Account business unit will always use `0`",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "integer",
+            "format" : "int64"
+          }
+        }, {
+          "name" : "channel",
+          "in" : "query",
+          "description" : "The channel type for the subscription type. Currently, the only supported channel type is `EMAIL`",
+          "required" : true,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "string",
+            "enum" : [ "EMAIL", "WHATSAPP", "SMS" ]
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ActionResponseWithResultsPublicStatus"
+                }
+              }
+            }
+          },
+          "default" : {
+            "$ref" : "#/components/responses/Error"
+          }
+        },
+        "security" : [ {
+          "private_apps_legacy" : [ "communication_preferences.read" ]
+        }, {
+          "oauth2_legacy" : [ "communication_preferences.read_write" ]
+        }, {
+          "private_apps_legacy" : [ "communication_preferences.read_write" ]
+        }, {
+          "oauth2_legacy" : [ "communication_preferences.read" ]
+        } ]
+      },
+      "post" : {
+        "tags" : [ "Subscription status" ],
+        "summary" : "Update a contact's subscription status",
+        "description" : "Set the subscription status of a specific contact.",
+        "operationId" : "post-/communication-preferences/v4/statuses/{subscriberIdString}",
+        "parameters" : [ {
+          "name" : "subscriberIdString",
+          "in" : "path",
+          "description" : "The contact's email address",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/PartialPublicStatusRequest"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ActionResponseWithResultsPublicStatus"
+                }
+              }
+            }
+          },
+          "default" : {
+            "$ref" : "#/components/responses/Error"
+          }
+        },
+        "security" : [ {
+          "oauth2_legacy" : [ "communication_preferences.write" ]
+        }, {
+          "oauth2_legacy" : [ "communication_preferences.read_write" ]
+        }, {
+          "private_apps_legacy" : [ "communication_preferences.write" ]
+        }, {
+          "private_apps_legacy" : [ "communication_preferences.read_write" ]
+        } ]
+      }
+    }
+  },
+  "components" : {
+    "schemas" : {
+      "ActionResponseWithResultsPublicWideStatus" : {
+        "required" : [ "completedAt", "results", "startedAt", "status" ],
+        "type" : "object",
+        "properties" : {
+          "completedAt" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "numErrors" : {
+            "type" : "integer",
+            "format" : "int32"
+          },
+          "requestedAt" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "startedAt" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "links" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "string"
+            }
+          },
+          "results" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/PublicWideStatus"
+            }
+          },
+          "errors" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/StandardError"
+            }
+          },
+          "status" : {
+            "type" : "string",
+            "enum" : [ "PENDING", "PROCESSING", "CANCELED", "COMPLETE" ]
+          }
+        }
+      },
+      "BatchInputString" : {
+        "required" : [ "inputs" ],
+        "type" : "object",
+        "properties" : {
+          "inputs" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          }
+        }
+      },
+      "PublicStatusBulkResponse" : {
+        "required" : [ "statuses", "subscriberIdString" ],
+        "type" : "object",
+        "properties" : {
+          "subscriberIdString" : {
+            "type" : "string"
+          },
+          "statuses" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/PublicStatus"
+            }
+          }
+        }
+      },
+      "StandardError" : {
+        "required" : [ "category", "context", "message", "status" ],
+        "type" : "object",
+        "properties" : {
+          "subCategory" : {
+            "type" : "object",
+            "properties" : { }
+          },
+          "context" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "array",
+              "items" : {
+                "type" : "string"
+              }
+            }
+          },
+          "links" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "string"
+            }
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "category" : {
+            "type" : "string"
+          },
+          "message" : {
+            "type" : "string"
+          },
+          "errors" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/ErrorDetail"
+            }
+          },
+          "status" : {
+            "type" : "string"
+          }
+        }
+      },
+      "PublicSubscriptionTranslation" : {
+        "required" : [ "createdAt", "description", "languageCode", "name", "subscriptionId", "updatedAt" ],
+        "type" : "object",
+        "properties" : {
+          "createdAt" : {
+            "type" : "integer",
+            "format" : "int32"
+          },
+          "name" : {
+            "type" : "string"
+          },
+          "description" : {
+            "type" : "string"
+          },
+          "subscriptionId" : {
+            "type" : "integer",
+            "format" : "int32"
+          },
+          "languageCode" : {
+            "type" : "string"
+          },
+          "updatedAt" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }
+      },
+      "PartialPublicStatusRequest" : {
+        "required" : [ "channel", "statusState", "subscriptionId" ],
+        "type" : "object",
+        "properties" : {
+          "statusState" : {
+            "type" : "string",
+            "enum" : [ "SUBSCRIBED", "UNSUBSCRIBED", "NOT_SPECIFIED" ]
+          },
+          "channel" : {
+            "type" : "string",
+            "enum" : [ "EMAIL", "WHATSAPP", "SMS" ]
+          },
+          "legalBasis" : {
+            "type" : "string",
+            "enum" : [ "LEGITIMATE_INTEREST_PQL", "LEGITIMATE_INTEREST_CLIENT", "PERFORMANCE_OF_CONTRACT", "CONSENT_WITH_NOTICE", "NON_GDPR", "PROCESS_AND_STORE", "LEGITIMATE_INTEREST_OTHER" ]
+          },
+          "subscriptionId" : {
+            "type" : "integer",
+            "format" : "int64"
+          },
+          "legalBasisExplanation" : {
+            "type" : "string"
+          }
+        }
+      },
+      "PublicStatus" : {
+        "required" : [ "channel", "source", "status", "subscriberIdString", "subscriptionId", "timestamp" ],
+        "type" : "object",
+        "properties" : {
+          "subscriptionName" : {
+            "type" : "string"
+          },
+          "channel" : {
+            "type" : "string",
+            "enum" : [ "EMAIL", "WHATSAPP", "SMS" ]
+          },
+          "subscriberIdString" : {
+            "type" : "string"
+          },
+          "legalBasis" : {
+            "type" : "string",
+            "nullable" : true,
+            "enum" : [ "LEGITIMATE_INTEREST_PQL", "LEGITIMATE_INTEREST_CLIENT", "PERFORMANCE_OF_CONTRACT", "CONSENT_WITH_NOTICE", "NON_GDPR", "PROCESS_AND_STORE", "LEGITIMATE_INTEREST_OTHER" ]
+          },
+          "setStatusSuccessReason" : {
+            "type" : "string",
+            "nullable" : true,
+            "enum" : [ "RESUBSCRIBE_OCCURRED", "NO_STATUS_CHANGE", "UNSUBSCRIBE_FROM_ALL_OCCURRED", "REQUESTED_CHANGE_OCCURRED" ]
+          },
+          "source" : {
+            "type" : "string"
+          },
+          "subscriptionId" : {
+            "type" : "integer",
+            "format" : "int32"
+          },
+          "legalBasisExplanation" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "businessUnitId" : {
+            "type" : "integer",
+            "format" : "int64"
+          },
+          "status" : {
+            "type" : "string",
+            "enum" : [ "SUBSCRIBED", "UNSUBSCRIBED", "NOT_SPECIFIED" ]
+          },
+          "timestamp" : {
+            "type" : "string",
+            "format" : "date-time"
+          }
+        }
+      },
+      "BatchResponsePublicStatus" : {
+        "required" : [ "completedAt", "results", "startedAt", "status" ],
+        "type" : "object",
+        "properties" : {
+          "completedAt" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "numErrors" : {
+            "type" : "integer",
+            "format" : "int32"
+          },
+          "requestedAt" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "startedAt" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "links" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "string"
+            }
+          },
+          "results" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/PublicStatus"
+            }
+          },
+          "errors" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/StandardError"
+            }
+          },
+          "status" : {
+            "type" : "string",
+            "enum" : [ "PENDING", "PROCESSING", "CANCELED", "COMPLETE" ]
+          }
+        }
+      },
+      "BatchResponsePublicStatusBulkResponseWithErrors" : {
+        "required" : [ "completedAt", "results", "startedAt", "status" ],
+        "type" : "object",
+        "properties" : {
+          "completedAt" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "numErrors" : {
+            "type" : "integer",
+            "format" : "int32"
+          },
+          "requestedAt" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "startedAt" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "links" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "string"
+            }
+          },
+          "results" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/PublicStatusBulkResponse"
+            }
+          },
+          "errors" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/StandardError"
+            }
+          },
+          "status" : {
+            "type" : "string",
+            "enum" : [ "PENDING", "PROCESSING", "CANCELED", "COMPLETE" ]
+          }
+        }
+      },
+      "Error" : {
+        "required" : [ "category", "correlationId", "message" ],
+        "type" : "object",
+        "properties" : {
+          "subCategory" : {
+            "type" : "string",
+            "description" : "A specific category that contains more specific detail about the error"
+          },
+          "context" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "array",
+              "items" : {
+                "type" : "string"
+              }
+            },
+            "description" : "Context about the error condition",
+            "example" : {
+              "missingScopes" : [ "scope1", "scope2" ],
+              "invalidPropertyName" : [ "propertyValue" ]
+            }
+          },
+          "correlationId" : {
+            "type" : "string",
+            "description" : "A unique identifier for the request. Include this value with any error reports or support tickets",
+            "format" : "uuid",
+            "example" : "aeb5f871-7f07-4993-9211-075dc63e7cbf"
+          },
+          "links" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "string"
+            },
+            "description" : "A map of link names to associated URIs containing documentation about the error or recommended remediation steps"
+          },
+          "message" : {
+            "type" : "string",
+            "description" : "A human readable message describing the error along with remediation steps where appropriate",
+            "example" : "An error occurred"
+          },
+          "category" : {
+            "type" : "string",
+            "description" : "The error category"
+          },
+          "errors" : {
+            "type" : "array",
+            "description" : "further information about the error",
+            "items" : {
+              "$ref" : "#/components/schemas/ErrorDetail"
+            }
+          }
+        },
+        "example" : {
+          "message" : "Invalid input (details will vary based on the error)",
+          "correlationId" : "aeb5f871-7f07-4993-9211-075dc63e7cbf",
+          "category" : "VALIDATION_ERROR",
+          "links" : {
+            "knowledge-base" : "https://www.hubspot.com/products/service/knowledge-base"
+          }
+        }
+      },
+      "PublicStatusRequest" : {
+        "required" : [ "channel", "statusState", "subscriberIdString", "subscriptionId" ],
+        "type" : "object",
+        "properties" : {
+          "statusState" : {
+            "type" : "string",
+            "description" : "The status of the contact's subscription",
+            "enum" : [ "SUBSCRIBED", "UNSUBSCRIBED", "NOT_SPECIFIED" ]
+          },
+          "channel" : {
+            "type" : "string",
+            "description" : "The type of communication channel. Currently, only `EMAIL` is supported",
+            "enum" : [ "EMAIL", "WHATSAPP", "SMS" ]
+          },
+          "subscriberIdString" : {
+            "type" : "string",
+            "description" : "The contact's email address"
+          },
+          "legalBasis" : {
+            "type" : "string",
+            "description" : "The legal basis for communication",
+            "enum" : [ "LEGITIMATE_INTEREST_PQL", "LEGITIMATE_INTEREST_CLIENT", "PERFORMANCE_OF_CONTRACT", "CONSENT_WITH_NOTICE", "NON_GDPR", "PROCESS_AND_STORE", "LEGITIMATE_INTEREST_OTHER" ]
+          },
+          "subscriptionId" : {
+            "type" : "integer",
+            "description" : "The ID of the subscription to update",
+            "format" : "int32"
+          },
+          "legalBasisExplanation" : {
+            "type" : "string",
+            "description" : "The explanation for the legal basis"
+          }
+        }
+      },
+      "PublicWideStatusBulkResponse" : {
+        "required" : [ "subscriberIdString", "wideStatuses" ],
+        "type" : "object",
+        "properties" : {
+          "wideStatuses" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/PublicWideStatus"
+            }
+          },
+          "subscriberIdString" : {
+            "type" : "string"
+          }
+        }
+      },
+      "BatchResponsePublicStatusBulkResponse" : {
+        "required" : [ "completedAt", "results", "startedAt", "status" ],
+        "type" : "object",
+        "properties" : {
+          "completedAt" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "requestedAt" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "startedAt" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "links" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "string"
+            }
+          },
+          "results" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/PublicStatusBulkResponse"
+            }
+          },
+          "status" : {
+            "type" : "string",
+            "enum" : [ "PENDING", "PROCESSING", "CANCELED", "COMPLETE" ]
+          }
+        }
+      },
+      "ActionResponseWithResultsPublicStatus" : {
+        "required" : [ "completedAt", "results", "startedAt", "status" ],
+        "type" : "object",
+        "properties" : {
+          "completedAt" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "numErrors" : {
+            "type" : "integer",
+            "format" : "int32"
+          },
+          "requestedAt" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "startedAt" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "links" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "string"
+            }
+          },
+          "results" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/PublicStatus"
+            }
+          },
+          "errors" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/StandardError"
+            }
+          },
+          "status" : {
+            "type" : "string",
+            "enum" : [ "PENDING", "PROCESSING", "CANCELED", "COMPLETE" ]
+          }
+        }
+      },
+      "BatchResponsePublicWideStatusBulkResponse" : {
+        "required" : [ "completedAt", "results", "startedAt", "status" ],
+        "type" : "object",
+        "properties" : {
+          "completedAt" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "requestedAt" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "startedAt" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "links" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "string"
+            }
+          },
+          "results" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/PublicWideStatusBulkResponse"
+            }
+          },
+          "status" : {
+            "type" : "string",
+            "enum" : [ "PENDING", "PROCESSING", "CANCELED", "COMPLETE" ]
+          }
+        }
+      },
+      "ErrorDetail" : {
+        "required" : [ "message" ],
+        "type" : "object",
+        "properties" : {
+          "subCategory" : {
+            "type" : "string",
+            "description" : "A specific category that contains more specific detail about the error"
+          },
+          "code" : {
+            "type" : "string",
+            "description" : "The status code associated with the error detail"
+          },
+          "in" : {
+            "type" : "string",
+            "description" : "The name of the field or parameter in which the error was found"
+          },
+          "context" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "array",
+              "items" : {
+                "type" : "string"
+              }
+            },
+            "description" : "Context about the error condition",
+            "example" : {
+              "missingScopes" : [ "scope1", "scope2" ]
+            }
+          },
+          "message" : {
+            "type" : "string",
+            "description" : "A human readable message describing the error along with remediation steps where appropriate"
+          }
+        }
+      },
+      "PublicWideStatus" : {
+        "required" : [ "channel", "status", "subscriberIdString", "timestamp", "wideStatusType" ],
+        "type" : "object",
+        "properties" : {
+          "wideStatusType" : {
+            "type" : "string",
+            "enum" : [ "PORTAL_WIDE", "BUSINESS_UNIT_WIDE" ]
+          },
+          "subscriberIdString" : {
+            "type" : "string"
+          },
+          "channel" : {
+            "type" : "string",
+            "enum" : [ "EMAIL", "WHATSAPP", "SMS" ]
+          },
+          "businessUnitId" : {
+            "type" : "integer",
+            "format" : "int64"
+          },
+          "status" : {
+            "type" : "string",
+            "enum" : [ "SUBSCRIBED", "UNSUBSCRIBED", "NOT_SPECIFIED" ]
+          },
+          "timestamp" : {
+            "type" : "string",
+            "format" : "date-time"
+          }
+        }
+      },
+      "ActionResponseWithResultsSubscriptionDefinition" : {
+        "required" : [ "completedAt", "results", "startedAt", "status" ],
+        "type" : "object",
+        "properties" : {
+          "completedAt" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "numErrors" : {
+            "type" : "integer",
+            "format" : "int32"
+          },
+          "requestedAt" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "startedAt" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "links" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "string"
+            }
+          },
+          "results" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/SubscriptionDefinition"
+            }
+          },
+          "errors" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/StandardError"
+            }
+          },
+          "status" : {
+            "type" : "string",
+            "enum" : [ "PENDING", "PROCESSING", "CANCELED", "COMPLETE" ]
+          }
+        }
+      },
+      "BatchInputPublicStatusRequest" : {
+        "required" : [ "inputs" ],
+        "type" : "object",
+        "properties" : {
+          "inputs" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/PublicStatusRequest"
+            }
+          }
+        }
+      },
+      "SubscriptionDefinition" : {
+        "required" : [ "createdAt", "description", "id", "isActive", "isDefault", "isInternal", "name", "updatedAt" ],
+        "type" : "object",
+        "properties" : {
+          "isInternal" : {
+            "type" : "boolean"
+          },
+          "createdAt" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "isDefault" : {
+            "type" : "boolean"
+          },
+          "communicationMethod" : {
+            "type" : "string"
+          },
+          "purpose" : {
+            "type" : "string"
+          },
+          "name" : {
+            "type" : "string"
+          },
+          "description" : {
+            "type" : "string"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "isActive" : {
+            "type" : "boolean"
+          },
+          "businessUnitId" : {
+            "type" : "integer",
+            "format" : "int64"
+          },
+          "subscriptionTranslations" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/PublicSubscriptionTranslation"
+            }
+          },
+          "updatedAt" : {
+            "type" : "string",
+            "format" : "date-time"
+          }
+        }
+      },
+      "BatchResponsePublicWideStatusBulkResponseWithErrors" : {
+        "required" : [ "completedAt", "results", "startedAt", "status" ],
+        "type" : "object",
+        "properties" : {
+          "completedAt" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "numErrors" : {
+            "type" : "integer",
+            "format" : "int32"
+          },
+          "requestedAt" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "startedAt" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "links" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "string"
+            }
+          },
+          "results" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/PublicWideStatusBulkResponse"
+            }
+          },
+          "errors" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/StandardError"
+            }
+          },
+          "status" : {
+            "type" : "string",
+            "enum" : [ "PENDING", "PROCESSING", "CANCELED", "COMPLETE" ]
+          }
+        }
+      },
+      "BatchResponsePublicBulkOptOutFromAllResponse" : {
+        "required" : [ "completedAt", "results", "startedAt", "status" ],
+        "type" : "object",
+        "properties" : {
+          "completedAt" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "numErrors" : {
+            "type" : "integer",
+            "format" : "int32"
+          },
+          "requestedAt" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "startedAt" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "links" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "string"
+            }
+          },
+          "results" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/PublicBulkOptOutFromAllResponse"
+            }
+          },
+          "errors" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/StandardError"
+            }
+          },
+          "status" : {
+            "type" : "string",
+            "enum" : [ "PENDING", "PROCESSING", "CANCELED", "COMPLETE" ]
+          }
+        }
+      },
+      "PublicBulkOptOutFromAllResponse" : {
+        "required" : [ "subscriberIdString" ],
+        "type" : "object",
+        "properties" : {
+          "subscriberIdString" : {
+            "type" : "string"
+          },
+          "statuses" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/PublicStatus"
+            }
+          }
+        }
+      }
+    },
+    "responses" : {
+      "Error" : {
+        "description" : "An error occurred.",
+        "content" : {
+          "*/*" : {
+            "schema" : {
+              "$ref" : "#/components/schemas/Error"
+            }
+          }
+        }
+      }
+    },
+    "securitySchemes" : {
+      "oauth2_legacy" : {
+        "type" : "oauth2",
+        "flows" : {
+          "authorizationCode" : {
+            "authorizationUrl" : "https://app.hubspot.com/oauth/authorize",
+            "tokenUrl" : "https://api.hubapi.com/oauth/v1/token",
+            "scopes" : {
+              "communication_preferences.read_write" : "Update contact subscription preferences",
+              "communication_preferences.read" : "Read contact subscription preferences",
+              "communication_preferences.write" : "Update contact subscription preferences"
+            }
+          }
+        }
+      },
+      "oauth2" : {
+        "type" : "oauth2",
+        "flows" : {
+          "authorizationCode" : {
+            "authorizationUrl" : "https://app.hubspot.com/oauth/authorize",
+            "tokenUrl" : "https://api.hubapi.com/oauth/v1/token",
+            "scopes" : {
+              "communication_preferences.statuses.batch.read" : "Batch read contact subscription preferences",
+              "communication_preferences.statuses.batch.write" : "Batch update contact subscription preferences"
+            }
+          }
+        }
+      },
+      "private_apps_legacy" : {
+        "type" : "apiKey",
+        "name" : "private-app-legacy",
+        "in" : "header",
+        "x-ballerina-name" : "privateAppLegacy"
+      },
+      "private_apps" : {
+        "type" : "apiKey",
+        "name" : "private-app",
+        "in" : "header",
+        "x-ballerina-name" : "privateApp"
+      }
+    }
+  }
+}

--- a/docs/spec/sanitations.md
+++ b/docs/spec/sanitations.md
@@ -1,6 +1,6 @@
 _Author_:  @SenuDyl\
 _Created_: 2025/01/03\
-_Updated_: 2026/06/18 \\
+_Updated_: 2026/06/18 \
 _Edition_: Swan Lake
 
 # Sanitation for OpenAPI specification

--- a/docs/spec/sanitations.md
+++ b/docs/spec/sanitations.md
@@ -1,6 +1,6 @@
 _Author_:  @SenuDyl\
 _Created_: 2025/01/03\
-_Updated_: 2025/01/09\
+_Updated_: 2026/06/18 \\
 _Edition_: Swan Lake
 
 # Sanitation for OpenAPI specification
@@ -41,4 +41,3 @@ The following command was used to generate the Ballerina client from the OpenAPI
 ```bash
 bal openapi -i docs/spec/openapi.json --mode client -o ballerina --client-methods remote --license docs/license.txt 
 ```
-


### PR DESCRIPTION
Improve operation summaries and add field descriptions

## Purpose

The Ballerina client generator builds doc comments solely from the OpenAPI `summary` field. Previously, only `description` was AI-improved, leaving `summary` fields as terse single words (e.g. "Read", "Archive", "Update") that produced unhelpful doc comments. This PR improves the developer experience by replacing those with concise, meaningful action phrases and adding field-level descriptions to generated types.

Fixes [wso2/product-integrator#1701](https://github.com/wso2/product-integrator/issues/1701)

## Changes

- Replace terse single-word operation summaries in `client.bal` with concise action phrases that accurately describe each operation, e.g. "Read" → "Retrieve a record by ID", "Archive" → "Archive a record by ID", "Update" → "Update a record by ID", "List" → "Retrieve a page of records".

- Condense any overlong summaries to fit the 35-character doc-comment cap.

- Add missing summaries where absent (e.g. search operations).

- Add AI-generated field-level descriptions to `types.bal` to improve generated documentation.

- Refresh `sanitations.md` with updated regeneration timestamp and add `aligned_ballerina_openapi.json` and `flattened_openapi.json` spec artifacts.

## Examples

**Before:**
```ballerina
# Read
resource isolated function get records/[string recordId](...) { }

# Archive
resource isolated function delete records/[string recordId](...) { }

# Update
resource isolated function patch records/[string recordId](...) { }
```

**After:**
```ballerina
# Retrieve a record by ID
resource isolated function get records/[string recordId](...) { }

# Archive a record by ID
resource isolated function delete records/[string recordId](...) { }

# Update a record by ID
resource isolated function patch records/[string recordId](...) { }
```

## Checklist
- [x] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility
